### PR TITLE
do not override custom Verdi_PATH

### DIFF
--- a/configure
+++ b/configure
@@ -7,7 +7,7 @@ DEPS=(StructTact Verdi)
 DIRS=(raft raft-proofs extraction/vard/coq)
 CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft")
 EXTRA=(raft/RaftState.v)
-Verdi_PATH=../verdi
+Verdi_PATH=${Verdi_PATH:="../verdi"}
 Verdi_DIRS=(core lib systems extraction/coq)
 NAMESPACE_Verdi_lib="\"\""
 NAMESPACE_Verdi_extraction_coq="\"\""


### PR DESCRIPTION
As originally written, the `configure` file always overrides a custom `Verdi_PATH`. This PR makes `configure` only use the default path when `Verdi_PATH` is not defined.
