### PR TITLE
symlink to extraction lib in Verdi in configure

### DIFF
--- a/configure
+++ b/configure
@@ -8,6 +8,7 @@ DIRS=(raft raft-proofs extraction/vard/coq)
 CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft")
 EXTRA=(raft/RaftState.v)
 Verdi_PATH=${Verdi_PATH:="../verdi"}
+ln -sfn $Verdi_PATH/extraction/ocaml extraction/vard/lib
 Verdi_DIRS=(core lib systems extraction/coq)
 NAMESPACE_Verdi_lib="\"\""
 NAMESPACE_Verdi_extraction_coq="\"\""

--- a/extraction/vard/.gitignore
+++ b/extraction/vard/.gitignore
@@ -2,3 +2,4 @@ coq/*.ml
 coq/*.mli
 _build
 vard.native
+lib

--- a/extraction/vard/lib
+++ b/extraction/vard/lib
@@ -1,1 +1,0 @@
-../../../verdi/extraction/ocaml


### PR DESCRIPTION
Set `lib` symlink in `extraction/vard` to `$Verdi_PATH/extraction/ocaml` in `configure`. Fixes bug where `vard` cannot run with `$Verdi_PATH` other than default `../verdi`.
