### PR TITLE
added missing Proof. for lemma candidate_entries_request_vote_reply

### DIFF
--- a/raft-proofs/CandidateEntriesProof.v
+++ b/raft-proofs/CandidateEntriesProof.v
@@ -528,6 +528,7 @@ Section CandidateEntriesProof.
 
   Lemma candidate_entries_request_vote_reply :
     refined_raft_net_invariant_request_vote_reply CandidateEntries.
+  Proof.
     red. unfold CandidateEntries. intros. intuition.
     - unfold candidateEntries_host_invariant in *.
       intros. simpl in *. eapply candidateEntries_ext; eauto.


### PR DESCRIPTION
To get accurate proofalytics and make quick compilation possible, all lemmas must have "Proof ..." before the proof script. This fixes that for one lemma we found. 
