### PR TITLE
separate printing of linearizability assumptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ proofalytics-aux: Makefile.coq
 	$(MAKE) -f Makefile.coq
 
 Makefile.coq: hacks _CoqProject
-	coq_makefile -f _CoqProject -o Makefile.coq -extra assumptions script/assumptions.v '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) script/assumptions.v'
+	coq_makefile -f _CoqProject -o Makefile.coq -extra 'script/assumptions.vo' 'script/assumptions.v raft-proofs/EndToEndLinearizability.vo' '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) script/assumptions.v'
 
 hacks: raft/RaftState.v
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ endif
 default: Makefile.coq
 	$(MAKE) -f Makefile.coq
 
+quick: Makefile.coq
+	$(MAKE) -f Makefile.coq quick
+
 proofalytics:
 	$(MAKE) -C proofalytics clean
 	$(MAKE) -C proofalytics
@@ -33,7 +36,7 @@ proofalytics-aux: Makefile.coq
 	$(MAKE) -f Makefile.coq
 
 Makefile.coq: hacks _CoqProject
-	coq_makefile -f _CoqProject -o Makefile.coq
+	coq_makefile -f _CoqProject -o Makefile.coq -extra assumptions script/assumptions.v '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) script/assumptions.v'
 
 hacks: raft/RaftState.v
 

--- a/raft-proofs/EndToEndLinearizability.v
+++ b/raft-proofs/EndToEndLinearizability.v
@@ -391,6 +391,3 @@ Section EndToEndProof.
   Qed.
 End EndToEndProof.
 
-About raft_linearizable.
-(*Print Assumptions raft_linearizable.*)
-

--- a/script/assumptions.v
+++ b/script/assumptions.v
@@ -1,0 +1,4 @@
+Require Import EndToEndLinearizability.
+
+About raft_linearizable.
+Print Assumptions raft_linearizable.

--- a/script/checkpaths.sh
+++ b/script/checkpaths.sh
@@ -12,7 +12,7 @@ fi
 
 
 grep '\.v' _CoqProject | sort > build.files
-find . -name '*.v' | sed 's!^\./!!' | sort > files
+find . -name '*.v' -not -path "./script/assumptions.v" | sed 's!^\./!!' | sort > files
 
 comm -23 files build.files > files.missing.from.build
 comm -13 files build.files > nonexistant.build.files


### PR DESCRIPTION
Coq quick compilation is not compatible with `Print Assumptions` commands. This contains a hack using `coq_makefile` to enable separation of printing of end-to-end linearizability assumptions from the compilation of .vio files. In the end, `Makefile.coq` contains a task `script/assumptions.vo` that compiles `scripts/assumptions.v` and is not a dependency of the `quick` task.
