### PR TITLE
added Verdi canary in configure

### DIFF
--- a/configure
+++ b/configure
@@ -5,7 +5,7 @@
 ## Configuration options for coqproject.sh
 DEPS=(StructTact Verdi)
 DIRS=(raft raft-proofs extraction/vard/coq)
-CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft")
+CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft" "Verdi.Verdi" "Build Verdi before building Verdi Raft")
 EXTRA=(raft/RaftState.v)
 Verdi_PATH=${Verdi_PATH:="../verdi"}
 ln -sfn $Verdi_PATH/extraction/ocaml extraction/vard/lib


### PR DESCRIPTION
This fixes the problem that there is no warning when running configure without having built Verdi.
