### PR TITLE
Fix extraction and documentation

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -8,6 +8,11 @@ pushd ..
     ./build.sh
   popd
 
+  git clone 'http://github.com/palmskog/InfSeqExt'
+  pushd InfSeqExt
+    ./build.sh
+  popd
+
   git clone 'http://github.com/uwplse/verdi' verdi
   pushd verdi
     ./build.sh

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,14 @@ proofalytics-aux: Makefile.coq
 
 ASSUMPTIONS_DEPS='script/assumptions.v raft-proofs/EndToEndLinearizability.vo'
 ASSUMPTIONS_COMMAND='$$(COQC) $$(COQDEBUG) $$(COQFLAGS) script/assumptions.v'
+VARDRAFT_DEPS='extraction/vard/coq/ExtractVarDRaft.v extraction/vard/coq/VarDRaft.vo'
+VARDRAFT_COMMAND='$$(COQC) $$(COQDEBUG) $$(COQFLAGS) extraction/vard/coq/ExtractVarDRaft.v'
 Makefile.coq: hacks _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq \
 	  -extra 'script/assumptions.vo' $(ASSUMPTIONS_DEPS) $(ASSUMPTIONS_COMMAND) \
-	  -extra 'script/assumptions.glob' $(ASSUMPTIONS_DEPS) $(ASSUMPTIONS_COMMAND)
+	  -extra 'script/assumptions.glob' $(ASSUMPTIONS_DEPS) $(ASSUMPTIONS_COMMAND) \
+          -extra 'extraction/vard/ml/VarDRaft.ml' $(VARDRAFT_DEPS) $(VARDRAFT_COMMAND) \
+          -extra 'extraction/vard/ml/VarDRaft.mli' $(VARDRAFT_DEPS) $(VARDRAFT_COMMAND) \
 
 hacks: raft/RaftState.v
 
@@ -59,9 +63,7 @@ vard:
 	@echo "To quickly provision vard use the vard-quick target."
 
 vard-quick: Makefile.coq
-	$(MAKE) -f Makefile.coq systems/VarD.vo
-	$(MAKE) -f Makefile.coq raft/Raft.vo
-	$(MAKE) -f Makefile.coq extraction/vard/coq/ExtractVarDRaft.vo
+	$(MAKE) -f Makefile.coq extraction/vard/ml/VarDRaft.ml extraction/vard/ml/VarDRaft.mli
 	cd extraction/vard; make
 
 lint:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ along the lines of [`etcd`](https://github.com/coreos/etcd).
 
 If the Raft implementation and its proofs have been compiled, all the files
 necessary to run `vard` on real hardware are in `extraction/vard`. It then
-suffices to run `make` in that directory to compile the extracted code, link it
+suffices to run `make` in that directory to compile the extracted OCaml code, link it
 against the Verdi shim and some `vard`-specific serialization/debugging code,
 and produce the `vard.native` binary. Alternatively, `make vard-quick` in the
 root directory produces the same result, but without compiling the Raft proofs.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Verdi Raft
 
 [![Build Status](https://api.travis-ci.org/uwplse/verdi-raft.svg?branch=master)](https://travis-ci.org/uwplse/verdi-raft)
 
-An implementation of the Raft distributed consensus protocol, verified in Coq using the Verdi framework.
+An implementation of the [Raft](https://raft.github.io) distributed consensus protocol, verified in Coq using the Verdi framework.
 
 Requirements
 ------------
@@ -39,17 +39,20 @@ subdirectory include:
   verification of Raft
 - `CommonTheorems.v`: several useful theorems about functions used by
   the Raft implementation
-- `OneLeaderPerTermInterface`: a statement of Raft's **Election
-  safety** property. See also the corresponding proof file in `raft-proofs`.
+- `OneLeaderPerTermInterface`: a statement of Raft's *election
+  safety* property. See also the corresponding proof file in `raft-proofs`.
   - `CandidatesVoteForSelvesInterface.v`, `VotesCorrectInterface.v`, and
     `CroniesCorrectInterface.v`: statements of properties used by the proof
     `OneLeaderPerTermProof.v`
-- `LogMatchingInterface.v`: a statement of Raft's *Log Matching*
-    property. See also `raft-proofs/LogMatchingProof.v`
+- `LogMatchingInterface.v`: a statement of Raft's *log matching*
+    property. See also `LogMatchingProof.v` in `raft-proofs`
   - `LeaderSublogInterface.v`, `SortedInterface.v`, and `UniqueIndicesInterface.v`: statements
    of properties used by `LogMatchingProof.v`
 
-The vard Key-Value Store
+The file `EndToEndLinearizability.v` in `raft-proofs` uses the proofs of
+all proof interfaces to show Raft's *linearizability* property.
+
+The `vard` Key-Value Store
 ------------------------
 
 Requirements:
@@ -57,59 +60,66 @@ Requirements:
 - `Coq 8.5`
 - `ocaml`, `ocamlbuild`
 
-vard is a simple key-value store implemented using
-Verdi. vard is specified and verified against Verdi's state-machine
-semantics in `VarD.v`. When the Raft transformer is applied, `vard`
-can be run as a strongly-consistent, fault-tolerant key-value store
-along the lines of etcd. The Coq and Ocaml files necessary to run vard
-on real hardware are in `extraction/vard`. Running `make` in that
-directory will extract the vard and Raft code, link it against the
-Verdi shim and some vard-specific serialization/debugging code, and
-compile it all into a `vard.native` binary. Running `make bench-vard`
-will produce some benchmark numbers, which are largely meaningless on
-localhost (multiple processes writing and fsync-ing to the same disk
+`vard` is a simple key-value store implemented using
+Verdi. `vard` is specified and verified against Verdi's state-machine
+semantics in the `VarD.v` example system distributed with Verdi. When the Raft transformer
+is applied, `vard` can be run as a strongly-consistent, fault-tolerant key-value store
+along the lines of [`etcd`](https://github.com/coreos/etcd).
+
+If the Raft implementation and its proofs have been compiled, all the files
+necessary to run `vard` on real hardware are in `extraction/vard`. It then
+suffices to run `make` in that directory to compile the extracted code, link it
+against the Verdi shim and some `vard`-specific serialization/debugging code,
+and produce the `vard.native` binary. Alternatively, `make vard-quick` in the
+root directory produces the same result, but without compiling the Raft proofs.
+
+Running `make bench-vard` in `extraction/vard` will produce some 
+benchmark numbers, which are largely meaningless on
+`localhost` (multiple processes writing and fsync-ing to the same disk
 and communicating over loopback doesn't accurately model real-world
 use cases). Running `make debug` will get you a `tmux` session where
 you can play around with a vard cluster in debug mode; look in
-`bench/vard.py` for a simple python `vard` client.
+`bench/vard.py` for a simple Python `vard` client.
 
-As the name suggests, vard is designed to be comparable to the etcd
+As the name suggests, `vard` is designed to be comparable to the `etcd`
 key-value store (although it currently supports many fewer
-features). To that end, we include a very simple etcd "client" which
+features). To that end, we include a very simple `etcd` "client" which
 can be used for benchmarking. Running `make bench-etcd` will run the
-vard benchmarks against etcd (although see above for why these results
+vard benchmarks against `etcd` (although see above for why these results
 are not particularly meaningful). See below for instructions to run
 both stores on a cluster in order to get a more useful performance
 comparison.
 
-Running vard on a cluster
--------------------------
+Running `vard` on a cluster
+---------------------------
 
-vard doesn't support run-time configuration, so in order to run vard
-in another configuration (i.e. on multiple hosts) you'll have to edit
-the `extraction/vard/ml/vard.ml` file, specifically the 4 lines starting
-with `let nodes = ...`. For instance, to run it on a cluster with ip
-addresses `192.168.0.1, 192.168.0.2, 192.168.0.3` you'd edit those
-lines to read
+`vard` accepts the following command-line options:
 
-    let nodes = [ (1, ("192.168.0.1", 9001))
-                ; (2, ("192.168.0.2", 9001))
-                ; (3, ("192.168.0.3", 9001))
-                ]
+```
+-me NAME             name for this node
+-port PORT`          port for client commands
+-dbpath DIRECTORY    directory for storing database files
+-node NAME,IP:PORT   node in the cluster
+-debug               run in debug mode
+```
 
-The port is the port used for internal communication; the client port
-is hard-coded to be `internal-port - 1000` (8001 in this
-example). After recompiling with this config, you could run the
-benchmarks on a cluster as follows:
+For example, to run `vard` on a cluster with IP addresses
+`192.168.0.1, 192.168.0.2, 192.168.0.3`, client port 8001,
+and port 9001 for internal communication, use the following:
 
     # on 192.168.0.1
-    $ ./vard.native 1
+    $ ./vard.native -dbpath /tmp/vard-8001 -port 8001 -me 1 -node 1,192.168.0.1:9001 \ 
+                    -node 2,192.168.0.2:9001 -node 3,192.168.0.3:9001
 
     # on 192.168.0.2
-    $ ./vard.native 2
-    
+    $ ./vard.native -dbpath /tmp/vard-8001 -port 8001 -me 2 -node 1,192.168.0.1:9001 \
+                    -node 2,192.168.0.2:9001 -node 3,192.168.0.3:9001
+
     # on 192.168.0.3
-    $ ./vard.native 3
+    $ ./vard.native -dbpath /tmp/vard-8001 -port 8001 -me 3 -node 1,192.168.0.1:9001 \ 
+                    -node 2,192.168.0.2:9001 -node 3,192.168.0.3:9001
+
+When the cluster is set up, a benchmark can be run as follows:
 
     # on the client machine
     $ python2 bench/setup.py --service vard --keys 50 \
@@ -119,10 +129,10 @@ benchmarks on a cluster as follows:
                              --threads 8 --requests 100
 
 
-Running etcd on a cluster
+Running `etcd` on a cluster
 -------------------------
 
-We can compare vard's numbers to etcd running on the same cluster as
+We can compare `vard`'s numbers to `etcd` running on the same cluster as
 follows:
 
     # on 192.168.0.1

--- a/extraction/vard/.gitignore
+++ b/extraction/vard/.gitignore
@@ -1,5 +1,5 @@
-coq/*.ml
-coq/*.mli
+ml/VarDRaft.ml
+ml/VarDRaft.mli
 _build
 vard.native
 lib

--- a/extraction/vard/Makefile
+++ b/extraction/vard/Makefile
@@ -1,8 +1,10 @@
-OCAMLBUILD = ocamlbuild -lib str -lib unix -I lib -I ml -I coq -cflag -g
+OCAMLBUILD = ocamlbuild -lib str -lib unix -I lib -I ml -cflag -g
+VARD = ml/VarDRaft.ml ml/VarDRaft.mli ml/VarDArrangement.ml ml/vard.ml
+LIB = lib/Shim.ml
 
 default: vard.native
 
-vard.native : ml/*.ml lib/*.ml
+vard.native: $(VARD) $(LIB)
 	$(OCAMLBUILD) vard.native
 
 clean:
@@ -25,4 +27,4 @@ bench-etcd: vard.native
 	./scripts/bench-etcd.sh
 	./scripts/clear-etcd.sh
 
-.PHONY : default coq run clear-data
+.PHONY: default run clear-data

--- a/extraction/vard/coq/ExtractVarDRaft.v
+++ b/extraction/vard/coq/ExtractVarDRaft.v
@@ -13,4 +13,4 @@ Require Import ExtrOcamlBool.
 Require Import ExtrOcamlList.
 Require Import ExtrOcamlFin.
 
-Extraction "extraction/vard/coq/VarDRaft.ml" seq vard_raft_base_params vard_raft_multi_params vard_raft_failure_params.
+Extraction "extraction/vard/ml/VarDRaft.ml" seq vard_raft_base_params vard_raft_multi_params vard_raft_failure_params.


### PR DESCRIPTION
Fix makefile to remove extracted files. Put all OCaml files in `ml` directory. Fix documentation. Fix Travis build script to fetch all Verdi dependencies.
