### PR TITLE
ocaml lib symlink should work with implicit Verdi_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,6 @@ lint:
 	find . -name '*.v' -exec grep -Hn 'H[0-9][0-9]*' {} \;
 
 distclean: clean
-	rm -f _CoqProject
+	rm -f _CoqProject extraction/vard/lib
 
-.PHONY: default clean vard vard-quick lint hacks proofalytics distclean
+.PHONY: default quick clean vard vard-quick lint hacks proofalytics distclean

--- a/configure
+++ b/configure
@@ -7,9 +7,9 @@ DEPS=(StructTact Verdi)
 DIRS=(raft raft-proofs extraction/vard/coq)
 CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft" "Verdi.Verdi" "Build Verdi before building Verdi Raft")
 EXTRA=(raft/RaftState.v)
-Verdi_PATH=${Verdi_PATH:="../verdi"}
-ln -sfn $Verdi_PATH/extraction/ocaml extraction/vard/lib
+Verdi_PATH=$(readlink --canonicalize ${Verdi_PATH:="../verdi"})
 Verdi_DIRS=(core lib systems extraction/coq)
 NAMESPACE_Verdi_lib="\"\""
 NAMESPACE_Verdi_extraction_coq="\"\""
 source script/coqproject.sh
+ln -sfn $Verdi_PATH/extraction/ocaml extraction/vard/lib


### PR DESCRIPTION
Fixes the issue that the symlink to Verdi's ocaml `lib` is broken when using implicit `Verdi_PATH`. Also avoids creating symlink when Verdi is not found at `Verdi_PATH`.
