### PR TITLE
allow zero as node name for vard to enable equivalence with all_fin

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,35 +97,37 @@ Running `vard` on a cluster
 
 ```
 -me NAME             name for this node
--port PORT`          port for client commands
+-port PORT           port for client commands
 -dbpath DIRECTORY    directory for storing database files
 -node NAME,IP:PORT   node in the cluster
 -debug               run in debug mode
 ```
 
+Note that `vard` node names are integers starting from 0.
+
 For example, to run `vard` on a cluster with IP addresses
-`192.168.0.1, 192.168.0.2, 192.168.0.3`, client port 8001,
-and port 9001 for internal communication, use the following:
+`192.168.0.1`, `192.168.0.2`, `192.168.0.3`, client (input) port 8000,
+and port 9000 for inter-node communication, use the following:
 
     # on 192.168.0.1
-    $ ./vard.native -dbpath /tmp/vard-8001 -port 8001 -me 1 -node 1,192.168.0.1:9001 \ 
-                    -node 2,192.168.0.2:9001 -node 3,192.168.0.3:9001
+    $ ./vard.native -dbpath /tmp/vard-8000 -port 8000 -me 0 -node 0,192.168.0.1:9000 \
+                    -node 1,192.168.0.2:9000 -node 2,192.168.0.3:9000
 
     # on 192.168.0.2
-    $ ./vard.native -dbpath /tmp/vard-8001 -port 8001 -me 2 -node 1,192.168.0.1:9001 \
-                    -node 2,192.168.0.2:9001 -node 3,192.168.0.3:9001
+    $ ./vard.native -dbpath /tmp/vard-8000 -port 8000 -me 1 -node 0,192.168.0.1:9000 \
+                    -node 1,192.168.0.2:9000 -node 2,192.168.0.3:9000
 
     # on 192.168.0.3
-    $ ./vard.native -dbpath /tmp/vard-8001 -port 8001 -me 3 -node 1,192.168.0.1:9001 \ 
-                    -node 2,192.168.0.2:9001 -node 3,192.168.0.3:9001
+    $ ./vard.native -dbpath /tmp/vard-8000 -port 8000 -me 2 -node 0,192.168.0.1:9000 \
+                    -node 1,192.168.0.2:9000 -node 2,192.168.0.3:9000
 
 When the cluster is set up, a benchmark can be run as follows:
 
     # on the client machine
     $ python2 bench/setup.py --service vard --keys 50 \
-                             --cluster "192.168.0.1:8001,192.168.0.2:8001,192.168.0.3:8001"
+                             --cluster "192.168.0.1:8000,192.168.0.2:8000,192.168.0.3:8000"
     $ python2 bench/bench.py --service vard --keys 50 \
-                             --cluster "192.168.0.1:8001,192.168.0.2:8001,192.168.0.3:8001" \
+                             --cluster "192.168.0.1:8000,192.168.0.2:8000,192.168.0.3:8000" \
                              --threads 8 --requests 100
 
 
@@ -137,34 +139,34 @@ follows:
 
     # on 192.168.0.1
     $ etcd --name=one \
-     --listen-client-urls http://192.168.0.1:8001 \
-     --advertise-client-urls http://192.168.0.1:8001 \
-     --initial-advertise-peer-urls http://192.168.0.1:9001 \
-     --listen-peer-urls http://192.168.0.1:9001 \
+     --listen-client-urls http://192.168.0.1:8000 \
+     --advertise-client-urls http://192.168.0.1:8000 \
+     --initial-advertise-peer-urls http://192.168.0.1:9000 \
+     --listen-peer-urls http://192.168.0.1:9000 \
      --data-dir=/tmp/etcd \
-     --initial-cluster "one=http://192.168.0.1:9001,two=http://192.168.0.2:9001,three=http://192.168.0.3:9001"
+     --initial-cluster "one=http://192.168.0.1:9000,two=http://192.168.0.2:9000,three=http://192.168.0.3:9000"
 
     # on 192.168.0.2
     $ etcd --name=two \
-     --listen-client-urls http://192.168.0.2:8001 \
-     --advertise-client-urls http://192.168.0.2:8001 \
-     --initial-advertise-peer-urls http://192.168.0.2:9001 \
-     --listen-peer-urls http://192.168.0.2:9001 \
+     --listen-client-urls http://192.168.0.2:8000 \
+     --advertise-client-urls http://192.168.0.2:8000 \
+     --initial-advertise-peer-urls http://192.168.0.2:9000 \
+     --listen-peer-urls http://192.168.0.2:9000 \
      --data-dir=/tmp/etcd \
-     --initial-cluster "one=http://192.168.0.1:9001,two=http://192.168.0.2:9001,three=http://192.168.0.3:9001"
+     --initial-cluster "one=http://192.168.0.1:9000,two=http://192.168.0.2:9000,three=http://192.168.0.3:9000"
 
     # on 192.168.0.3
     $ etcd --name=three \
-     --listen-client-urls http://192.168.0.3:8001 \
-     --advertise-client-urls http://192.168.0.3:8001 \
-     --initial-advertise-peer-urls http://192.168.0.3:9001 \
-     --listen-peer-urls http://192.168.0.3:9001 \
+     --listen-client-urls http://192.168.0.3:8000 \
+     --advertise-client-urls http://192.168.0.3:8000 \
+     --initial-advertise-peer-urls http://192.168.0.3:9000 \
+     --listen-peer-urls http://192.168.0.3:9000 \
      --data-dir=/tmp/etcd \
-     --initial-cluster "one=http://192.168.0.1:9001,two=http://192.168.0.2:9001,three=http://192.168.0.3:9001"
+     --initial-cluster "one=http://192.168.0.1:9000,two=http://192.168.0.2:9000,three=http://192.168.0.3:9000"
 
     # on the client machine
     $ python2 bench/setup.py --service etcd --keys 50 \
-                             --cluster "192.168.0.1:8001,192.168.0.2:8001,192.168.0.3:8001"
+                             --cluster "192.168.0.1:8000,192.168.0.2:8000,192.168.0.3:8000"
     $ python2 bench/bench.py --service etcd --keys 50 \
-                             --cluster "192.168.0.1:8001,192.168.0.2:8001,192.168.0.3:8001" \
+                             --cluster "192.168.0.1:8000,192.168.0.2:8000,192.168.0.3:8000" \
                              --threads 8 --requests 100

--- a/extraction/vard/ml/vard.ml
+++ b/extraction/vard/ml/vard.ml
@@ -18,7 +18,7 @@ let node_spec arg nodes_ref doc =
 let _ =
 
   let cluster = ref [] in
-  let me = ref 0 in
+  let me = ref (-1) in
   let port = ref 8351 in
   let dbpath = ref "/var/lib/vard" in
   let debug = ref false in
@@ -27,7 +27,7 @@ let _ =
     if length !cluster == 0 then begin
       raise (Arg.Bad "Please specify at least one -node")
     end;
-    if !me == 0 then begin
+    if !me == -1 then begin
       raise (Arg.Bad "Please specify the node name -me")
     end;
     if not (mem_assoc !me !cluster) then begin
@@ -36,7 +36,7 @@ let _ =
   in
 
   let opts =
-    [ node_spec "-node" cluster "{id,host:port} one node in the cluster"
+    [ node_spec "-node" cluster "{name,host:port} one node in the cluster"
     ; ("-me", Arg.Set_int me, "{name} name for this node")
     ; ("-port", Arg.Set_int port, "{port} port for client commands")
     ; ("-dbpath", Arg.Set_string dbpath, "{path} directory for storing database files")

--- a/extraction/vard/scripts/bench-vard.sh
+++ b/extraction/vard/scripts/bench-vard.sh
@@ -4,17 +4,17 @@ function start-vard {
   PORT=800${1}
   ./vard.native -dbpath "/tmp/vard-$PORT" \
                 -port "$PORT" \
-                -node 1,localhost:9001 -node 2,localhost:9002 -node 3,localhost:9003 \
+                -node 0,localhost:9000 -node 1,localhost:9001 -node 2,localhost:9002 \
                 -me "$1" \
                 > "/tmp/vard-${PORT}.log" &
   sleep 1
 }
 
+start-vard 0
 start-vard 1
 start-vard 2
-start-vard 3
 
-python2 bench/setup.py --service vard --keys 50 --cluster "localhost:8001,localhost:8002,localhost:8003"
-python2 bench/bench.py --service vard --keys 50 --cluster "localhost:8001,localhost:8002,localhost:8003" --threads 8 --requests 100
+python2 bench/setup.py --service vard --keys 50 --cluster "localhost:8000,localhost:8001,localhost:8002"
+python2 bench/bench.py --service vard --keys 50 --cluster "localhost:8000,localhost:8001,localhost:8002" --threads 8 --requests 100
 
 killall -9 vard.native > /dev/null


### PR DESCRIPTION
Extraction for `all_fin` was changed to start from 0 rather than 1 to match `fin_to_nat`. Here is an update to `vard.ml` to enable setting node names to 0 when using extracted code. The README is updated to reflect this. Ideally, whether the collection of nodes passed on the command line matches the extracted `all_fin` names should be checked.
