### PR TITLE
Adapt VarD arrangement to new unordered shim

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,7 +1,7 @@
 opam init --yes --no-setup
 eval $(opam config env)
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq.$COQ_VERSION coq-mathcomp-ssreflect.$SSREFLECT_VERSION ounit.2.0.0 --yes --verbose
+opam install coq.$COQ_VERSION coq-mathcomp-ssreflect.$SSREFLECT_VERSION ounit.2.0.0 uuidm.0.9.6 --yes --verbose
 
 pushd ..
   git clone 'http://github.com/uwplse/StructTact'

--- a/extraction/vard/Makefile
+++ b/extraction/vard/Makefile
@@ -1,7 +1,7 @@
 PYTHON=python2.7
 
-OCAMLBUILD = ocamlbuild -lib str -lib unix -I lib -I ml -cflag -g
-OCAMLBUILD_TEST = ocamlbuild -package oUnit -lib str -I lib -I ml -I test -cflag -g
+OCAMLBUILD = ocamlbuild -package uuidm -lib str -lib unix -I lib -I ml -cflag -g
+OCAMLBUILD_TEST = ocamlbuild -package uuidm -package oUnit -lib str -I lib -I ml -I test -cflag -g
 
 VARD = ml/VarDRaft.ml ml/VarDRaft.mli ml/VarDArrangement.ml ml/vard.ml ml/VarDSerialization.ml
 VARD_TEST = test/TestCommon.ml test/OptsTest.ml test/VarDSerializationTest.ml test/VarDTest.ml

--- a/extraction/vard/ml/VarDArrangement.ml
+++ b/extraction/vard/ml/VarDArrangement.ml
@@ -29,7 +29,7 @@ module VarDArrangement (P : VardParams) = struct
   type output = VarDRaft.raft_output
   type msg = VarDRaft.msg
   type res = (VarDRaft.raft_output list * raft_data0) * ((VarDRaft.name * VarDRaft.msg) list)
-  type request_id = (int * int)
+  type client_id = int
   let systemName = "VarD"
   let init x = Obj.magic (init_handlers0 vard_base_params vard_one_node_params raft_params x)
   let reboot = Obj.magic (reboot vard_base_params raft_params)
@@ -69,4 +69,7 @@ module VarDArrangement (P : VardParams) = struct
      | _ -> ()); flush_all ()
   let debugTimeout (s : state) = ()
   let debugInput s inp = ()
+  let createClientId () =
+    let client_uuid = Uuidm.to_string (Uuidm.create `V4) in
+    int_of_string ("0x" ^ String.sub client_uuid 0 8)
 end

--- a/extraction/vard/ml/VarDSerialization.ml
+++ b/extraction/vard/ml/VarDSerialization.ml
@@ -6,54 +6,50 @@ open Util
 
 let serializeOutput out =
   match (Obj.magic out) with
-  | NotLeader (client, id) ->
-     ((client, id), sprintf "NotLeader %s %s" (string_of_int client) (string_of_int id))
-  | ClientResponse (client, id, o) ->
+  | NotLeader (client_id, request_id) ->
+    (client_id, sprintf "NotLeader %s" (string_of_int request_id))
+  | ClientResponse (client_id, request_id, o) ->
      let Response (k, value, old) = (Obj.magic o) in
-     ((client, id),
+     (client_id,
       match (value, old) with
-      | Some v, Some o -> sprintf "Response %s %s %s %s %s"
-                                 (string_of_int client)
-                                 (string_of_int id)
+      | Some v, Some o -> sprintf "Response %s %s %s %s"
+                                 (string_of_int request_id)
                                  (string_of_char_list k)
                                  (string_of_char_list v)
                                  (string_of_char_list o)
-      | Some v, None -> sprintf "Response %s %s %s %s -"
-                               (string_of_int client)
-                               (string_of_int id)
+      | Some v, None -> sprintf "Response %s %s %s -"
+                               (string_of_int request_id)
                                (string_of_char_list k)
                                (string_of_char_list v)
-      | None, Some o -> sprintf "Response %s %s %s - %s"
-                               (string_of_int client)
-                               (string_of_int id)
+      | None, Some o -> sprintf "Response %s %s - %s"
+                               (string_of_int request_id)
                                (string_of_char_list k)
                                (string_of_char_list o)
-      | None, None -> sprintf "Response %s %s %s - -"
-                             (string_of_int client)
-                             (string_of_int id)
+      | None, None -> sprintf "Response %s %s - -"
+                             (string_of_int request_id)
                              (string_of_char_list k))
 
 let deserializeInp i =
   let inp = String.trim i in
-  let r = regexp "\\([0-9]+\\) \\([0-9]+\\) \\([A-Z]+\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\)[^/A-za-z0-9]*" in
+  let r = regexp "\\([0-9]+\\) \\([A-Z]+\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\)[^/A-za-z0-9]*" in
   if string_match r inp 0 then
     (match (matched_group 1 inp, matched_group 2 inp,
             matched_group 3 inp, matched_group 4 inp,
-            matched_group 5 inp, matched_group 6 inp) with
-     | (c, i, "GET", k, _, _) -> Some (int_of_string c, int_of_string i, Get (char_list_of_string k))
-     | (c, i, "DEL", k, _, _) -> Some (int_of_string c, int_of_string i, Del (char_list_of_string k))
-     | (c, i, "PUT", k, v, _) -> Some (int_of_string c, int_of_string i, Put ((char_list_of_string k), (char_list_of_string v)))
-     | (c, i, "CAD", k, o, _) -> Some (int_of_string c, int_of_string i, CAD (char_list_of_string k, char_list_of_string o))
-     | (c, i, "CAS", k, "-", v) -> Some (int_of_string c, int_of_string i, CAS ((char_list_of_string k), None, (char_list_of_string v)))
-     | (c, i, "CAS", k, o, v) -> Some (int_of_string c, int_of_string i, CAS ((char_list_of_string k), Some (char_list_of_string o), (char_list_of_string v)))
+            matched_group 5 inp) with
+     | (i, "GET", k, _, _) -> Some (int_of_string i, Get (char_list_of_string k))
+     | (i, "DEL", k, _, _) -> Some (int_of_string i, Del (char_list_of_string k))
+     | (i, "PUT", k, v, _) -> Some (int_of_string i, Put ((char_list_of_string k), (char_list_of_string v)))
+     | (i, "CAD", k, o, _) -> Some (int_of_string i, CAD (char_list_of_string k, char_list_of_string o))
+     | (i, "CAS", k, "-", v) -> Some (int_of_string i, CAS ((char_list_of_string k), None, (char_list_of_string v)))
+     | (i, "CAS", k, o, v) -> Some (int_of_string i, CAS ((char_list_of_string k), Some (char_list_of_string o), (char_list_of_string v)))
      | _ -> None)
   else
     (print_endline "No match" ; None)
 
-let deserializeInput inp =
-  match (deserializeInp inp) with
-  | Some (client, id, input) ->
-     Some ((client, id), (ClientRequest (client, id, (Obj.magic input))))
+let deserializeInput inp client_id =
+  match deserializeInp inp with
+  | Some (request_id, input) ->
+    Some (ClientRequest (client_id, request_id, Obj.magic input))
   | None -> None
 
 let deserializeMsg (s : string) : VarDRaft.msg = Marshal.from_string s 0

--- a/extraction/vard/test/VarDSerializationTest.ml
+++ b/extraction/vard/test/VarDSerializationTest.ml
@@ -6,12 +6,12 @@ open Util
 let tear_down () text_ctxt = ()
 
 let test_serialize_output_not_leader text_ctxt =
-  assert_equal ((2, 15), "NotLeader 2 15")
+  assert_equal (2, "NotLeader 15")
     (VarDSerialization.serializeOutput (VarDRaft.NotLeader (2, 15)))
 
 let test_serialize_output_client_response test_ctxt =
   let o = VarDRaft.Response (char_list_of_string "awesome", None, None) in
-  assert_equal ((3, 34), "Response 3 34 awesome - -")
+  assert_equal (3, "Response 34 awesome - -")
     (VarDSerialization.serializeOutput (VarDRaft.ClientResponse (3, 34, (Obj.magic o))))
   
 let test_list =


### PR DESCRIPTION
Change the VarD arrangement and serialization to define custom client id type and generator, to fit a new more general unordered shim. This PR should only be merged after the [Verdi PR](https://github.com/uwplse/verdi/pull/89) that refactors the unordered shim is merged.
