### PR TITLE
remove Uuidm dependency, use Random to create VarD client ids

### DIFF
--- a/extraction/vard/Makefile
+++ b/extraction/vard/Makefile
@@ -1,7 +1,7 @@
 PYTHON=python2.7
 
-OCAMLBUILD = ocamlbuild -package uuidm -lib str -lib unix -I lib -I ml -cflag -g
-OCAMLBUILD_TEST = ocamlbuild -package uuidm -package oUnit -lib str -I lib -I ml -I test -cflag -g
+OCAMLBUILD = ocamlbuild -lib str -lib unix -I lib -I ml -cflag -g
+OCAMLBUILD_TEST = ocamlbuild -package oUnit -lib str -I lib -I ml -I test -cflag -g
 
 VARD = ml/VarDRaft.ml ml/VarDRaft.mli ml/VarDArrangement.ml ml/vard.ml ml/VarDSerialization.ml
 VARD_TEST = test/TestCommon.ml test/OptsTest.ml test/VarDSerializationTest.ml test/VarDTest.ml

--- a/extraction/vard/ml/VarDArrangement.ml
+++ b/extraction/vard/ml/VarDArrangement.ml
@@ -70,6 +70,6 @@ module VarDArrangement (P : VardParams) = struct
   let debugTimeout (s : state) = ()
   let debugInput s inp = ()
   let createClientId () =
-    let client_uuid = Uuidm.to_string (Uuidm.create `V4) in
-    int_of_string ("0x" ^ String.sub client_uuid 0 8)
+    let upper_bound = 1073741823 in
+    Random.int upper_bound
 end


### PR DESCRIPTION
Since VarD uses ints for client ids, UUID can't give the usual guarantees of uniqueness, and introduces a dependency on a separate package (Uuidm). Here, I replace Uuidm calls with standard calls to random, to generate a pseudorandom integer in the range 0 to 2^30 - 1. Arguably, uniqueness of client ids is not obviously worse off by this change, since Random.self_init uses system entropy when available.