### PR TITLE
Fix configure script for Mac OS X

### DIFF
--- a/configure
+++ b/configure
@@ -7,7 +7,7 @@ DEPS=(StructTact Verdi)
 DIRS=(raft raft-proofs extraction/vard/coq)
 CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft" "Verdi.Verdi" "Build Verdi before building Verdi Raft")
 EXTRA=(raft/RaftState.v)
-Verdi_PATH=$(readlink -f ${Verdi_PATH:="../verdi"})
+Verdi_PATH=$(perl -MCwd -e 'print Cwd::abs_path shift' ${Verdi_PATH:="../verdi"})
 Verdi_DIRS=(core lib systems extraction/coq)
 NAMESPACE_Verdi_lib="\"\""
 NAMESPACE_Verdi_extraction_coq="\"\""

--- a/configure
+++ b/configure
@@ -7,7 +7,7 @@ DEPS=(StructTact Verdi)
 DIRS=(raft raft-proofs extraction/vard/coq)
 CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft" "Verdi.Verdi" "Build Verdi before building Verdi Raft")
 EXTRA=(raft/RaftState.v)
-Verdi_PATH=$(readlink --canonicalize ${Verdi_PATH:="../verdi"})
+Verdi_PATH=$(readlink -f ${Verdi_PATH:="../verdi"})
 Verdi_DIRS=(core lib systems extraction/coq)
 NAMESPACE_Verdi_lib="\"\""
 NAMESPACE_Verdi_extraction_coq="\"\""


### PR DESCRIPTION
Use perl to get OS-independent absolute path of Verdi for symlinking.