### PR TITLE
Fix parallel make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ vard:
 $(MLFILES): Makefile.coq
 	$(MAKE) -f Makefile.coq $@
 
-vard-quick: $(MLFILES)
+vard-quick:
 	$(MAKE) -C extraction/vard
 
-vard-test: $(MLFILES)
+vard-test:
 	$(MAKE) -C extraction/vard test
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,10 @@ $(MLFILES): Makefile.coq
 	$(MAKE) -f Makefile.coq $@
 
 vard-quick:
-	$(MAKE) -C extraction/vard
+	+$(MAKE) -C extraction/vard
 
 vard-test:
-	$(MAKE) -C extraction/vard test
+	+$(MAKE) -C extraction/vard test
 
 lint:
 	@echo "Possible use of hypothesis names:"

--- a/extraction/vard/Makefile
+++ b/extraction/vard/Makefile
@@ -14,7 +14,7 @@ vard.native: $(LIB) $(VARD) $(VARDRAFT)
 	$(OCAMLBUILD) vard.native
 
 $(VARDRAFT):
-	make -C ../.. extraction/vard/$@
+	+$(MAKE) -C ../.. extraction/vard/$@
 
 VarDTest.native: $(LIB) $(VARD) $(VARDRAFT) $(VARD_TEST)
 	$(OCAMLBUILD_TEST) VarDTest.native
@@ -28,8 +28,7 @@ test-integration: vard.native test/integration.py
 test: test-units test-integration
 
 clean:
-	$(OCAMLBUILD) vard.native -clean
-	$(OCAMLBUILD_TEST) VarDTest.native -clean
+	$(OCAMLBUILD) -clean
 
 clear-data:
 	./scripts/clear-vard.sh
@@ -51,3 +50,4 @@ bench-etcd: vard.native
 .PHONY: default test-units test-integration test clean clear-data run debug bench-vard bench-etcd $(VARDRAFT)
 
 .NOTPARALLEL: vard.native VarDTest.native
+.NOTPARALLEL: $(VARDRAFT)


### PR DESCRIPTION
Hopefully fix all nondeterminism in travis build by properly deferring dependencies, passing job servers, and preventing dangerous parallelism.