### PR TITLE
add serializeClientId definition to vard arrangement

### DIFF
--- a/extraction/vard/ml/VarDArrangement.ml
+++ b/extraction/vard/ml/VarDArrangement.ml
@@ -72,4 +72,5 @@ module VarDArrangement (P : VardParams) = struct
   let createClientId () =
     let upper_bound = 1073741823 in
     Random.int upper_bound
+  let serializeClientId = string_of_int
 end


### PR DESCRIPTION
Makes more verbose client error messages possible. This PR should only be merged after the corresponding [Verdi PR](https://github.com/uwplse/verdi/pull/93) has been merged.