### PR TITLE
change vard to use cluster size based on command line parameters

### DIFF
--- a/extraction/vard/coq/VarDRaft.v
+++ b/extraction/vard/coq/VarDRaft.v
@@ -2,9 +2,11 @@ Require Import Raft.
 Require Import Verdi.VarD.
 
 Section VarDRaft.
+  Variable n : nat.
+
   Instance raft_params : RaftParams vard_base_params :=
     {
-      N := 3;
+      N := n;
       input_eq_dec := input_eq_dec;
       output_eq_dec := output_eq_dec
     }.

--- a/extraction/vard/ml/VarDArrangement.ml
+++ b/extraction/vard/ml/VarDArrangement.ml
@@ -4,22 +4,33 @@ open VarDRaft
 open VarD
 open Util
 
+module type IntValue = sig
+  val v : int
+end
+
 module type VardParams = sig
   val debug : bool
   val heartbeat_timeout : float
   val election_timeout : float
+  val num_nodes : int
 end
 
-module DebugParams = struct
+module DebugParams =
+  functor (I : IntValue) ->
+struct
   let debug = true
   let heartbeat_timeout = 2.0
   let election_timeout = 10.0
+  let num_nodes = I.v
 end
 
-module BenchParams = struct
+module BenchParams =
+  functor (I : IntValue) ->
+struct
   let debug = false
   let heartbeat_timeout = 0.05
   let election_timeout = 0.5
+  let num_nodes = I.v
 end
 
 module VarDArrangement (P : VardParams) = struct
@@ -31,12 +42,12 @@ module VarDArrangement (P : VardParams) = struct
   type res = (VarDRaft.raft_output list * raft_data0) * ((VarDRaft.name * VarDRaft.msg) list)
   type client_id = int
   let systemName = "VarD"
-  let init x = Obj.magic (init_handlers0 vard_base_params vard_one_node_params raft_params x)
-  let reboot = Obj.magic (reboot vard_base_params raft_params)
-  let handleIO (n : name) (inp : input) (st : state) = Obj.magic (vard_raft_multi_params.input_handlers (Obj.magic n) (Obj.magic inp) (Obj.magic st))
-  let handleNet (n : name) (src: name) (m : msg) (st : state)  = Obj.magic (vard_raft_multi_params.net_handlers (Obj.magic n) (Obj.magic src) (Obj.magic m) (Obj.magic st))
+  let init x = Obj.magic (init_handlers0 vard_base_params vard_one_node_params (raft_params P.num_nodes) x)
+  let reboot = Obj.magic (reboot vard_base_params (raft_params P.num_nodes))
+  let handleIO (n : name) (inp : input) (st : state) = Obj.magic ((vard_raft_multi_params P.num_nodes).input_handlers (Obj.magic n) (Obj.magic inp) (Obj.magic st))
+  let handleNet (n : name) (src: name) (m : msg) (st : state)  = Obj.magic ((vard_raft_multi_params P.num_nodes).net_handlers (Obj.magic n) (Obj.magic src) (Obj.magic m) (Obj.magic st))
   let handleTimeout (me : name) (st : state) =
-    (Obj.magic vard_raft_multi_params.input_handlers (Obj.magic me) (Obj.magic Timeout) (Obj.magic st))
+    (Obj.magic (vard_raft_multi_params P.num_nodes).input_handlers (Obj.magic me) (Obj.magic Timeout) (Obj.magic st))
   let setTimeout _ s =
     match s.type0 with
     | Leader -> P.heartbeat_timeout

--- a/extraction/vard/ml/vard.ml
+++ b/extraction/vard/ml/vard.ml
@@ -4,13 +4,22 @@ open Str
 open Opts
 
 let _ =
-  let  _ = parse Sys.argv in
-
+  let _ =
+    try
+      parse Sys.argv
+    with
+    | Arg.Help msg ->
+      printf "%s: %s" Sys.argv.(0) msg;
+      exit 2
+    | Arg.Bad msg ->
+      eprintf "%s" msg;
+      exit 2
+  in
   let _ =
     try
       validate ()
     with Arg.Bad msg ->
-      eprintf "%s: %s." Sys.argv.(0) msg;
+      eprintf "%s: %s" Sys.argv.(0) msg;
       prerr_newline ();
       exit 2
   in

--- a/extraction/vard/ml/vard.ml
+++ b/extraction/vard/ml/vard.ml
@@ -3,9 +3,6 @@ open Printf
 open Str
 open Opts
 
-module VarDDebug = Shim.Shim(VarDArrangement.VarDArrangement(VarDArrangement.DebugParams))
-module VarDBench = Shim.Shim(VarDArrangement.VarDArrangement(VarDArrangement.BenchParams))
-
 let _ =
   let  _ = parse Sys.argv in
 
@@ -17,16 +14,22 @@ let _ =
       prerr_newline ();
       exit 2
   in
-
+  let module NumNodes = struct let v = length !cluster end in
   if !debug then
-    let open VarDDebug in
+    let module VarD =
+      Shim.Shim(VarDArrangement.VarDArrangement(VarDArrangement.DebugParams(NumNodes)))
+    in
+    let open VarD in
     main { cluster = !cluster
          ; me = !me
          ; port = !port
          ; dbpath = !dbpath
          }
   else
-    let open VarDBench in
+    let module VarD =
+      Shim.Shim(VarDArrangement.VarDArrangement(VarDArrangement.BenchParams(NumNodes)))
+    in
+    let open VarD in
     main { cluster = !cluster
          ; me = !me
          ; port = !port


### PR DESCRIPTION
Use first-class modules to set Raft cluster size at runtime rather than compile-time. This solves the long-standing problem that the shim raises `Not_found` whenever the static cluster size differs from the number of nodes in cluster passed from the command line.