### PR TITLE
Use Verdi namespace when importing Verdi files

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -14,7 +14,7 @@ pushd ..
     ./build.sh $TARGET
   popd
 
-  git clone 'https://github.com/uwplse/verdi.git'
+  git clone -b namespacing 'https://github.com/uwplse/verdi.git'
   pushd verdi
     ./build.sh $TARGET
   popd

--- a/configure
+++ b/configure
@@ -9,7 +9,5 @@ CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be ins
 EXTRA=(raft/RaftState.v)
 Verdi_PATH=$(perl -MCwd -e 'print Cwd::abs_path shift' ${Verdi_PATH:="../verdi"})
 Verdi_DIRS=(core lib systems extraction/coq)
-NAMESPACE_Verdi_lib="\"\""
-NAMESPACE_Verdi_extraction_coq="\"\""
 source script/coqproject.sh
 ln -sfn $Verdi_PATH/extraction/ocaml extraction/vard/lib

--- a/extraction/vard/coq/ExtractVarDRaft.v
+++ b/extraction/vard/coq/ExtractVarDRaft.v
@@ -6,11 +6,11 @@ Require Import ExtrOcamlBasic.
 Require Import ExtrOcamlNatInt.
 Require Import ExtrOcamlString.
 
-Require Import ExtrOcamlBasicExt.
-Require Import ExtrOcamlNatIntExt.
+Require Import Verdi.ExtrOcamlBasicExt.
+Require Import Verdi.ExtrOcamlNatIntExt.
 
-Require Import ExtrOcamlBool.
-Require Import ExtrOcamlList.
-Require Import ExtrOcamlFin.
+Require Import Verdi.ExtrOcamlBool.
+Require Import Verdi.ExtrOcamlList.
+Require Import Verdi.ExtrOcamlFin.
 
 Extraction "extraction/vard/ml/VarDRaft.ml" seq vard_raft_base_params vard_raft_multi_params vard_raft_failure_params.


### PR DESCRIPTION
To prepare for making an OPAM package for Verdi, the namespace `Verdi` must be used for every Verdi Coq file. This PR sets the namespace of some Verdi imports that didn't have them, and should only be merged after the corresponding [Verdi PR](https://github.com/uwplse/verdi/pull/100) has been merged.

Commit bede997 should not be included when merging.