### PR TITLE
Switch to verdi-runtime library and add OPAM compatibility

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,24 +1,8 @@
 opam init --yes --no-setup
 eval $(opam config env)
 opam repo add coq-released https://coq.inria.fr/opam/released
-opam install coq.$COQ_VERSION coq-mathcomp-ssreflect.$SSREFLECT_VERSION ounit.2.0.0 uuidm.0.9.6 --yes --verbose
-
-pushd ..
-  git clone 'https://github.com/uwplse/StructTact.git'
-  pushd StructTact
-    ./build.sh $TARGET
-  popd
-
-  git clone 'https://github.com/DistributedComponents/InfSeqExt.git'
-  pushd InfSeqExt
-    ./build.sh $TARGET
-  popd
-
-  git clone 'https://github.com/uwplse/verdi.git'
-  pushd verdi
-    ./build.sh $TARGET
-  popd
-popd
+opam repo add distributedcomponents http://opam.distributedcomponents.net
+opam install coq.$COQ_VERSION coq-mathcomp-ssreflect.$SSREFLECT_VERSION StructTact verdi verdi-runtime ounit.2.0.0 --yes --verbose
 
 case $MODE in
   analytics)

--- a/Makefile
+++ b/Makefile
@@ -46,15 +46,17 @@ Makefile.coq: raft/RaftState.v _CoqProject
 	    '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) script/assumptions.v' \
           -extra '$(MLFILES)' \
 	    'extraction/vard/coq/ExtractVarDRaft.v extraction/vard/coq/VarDRaft.vo' \
-	    '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) extraction/vard/coq/ExtractVarDRaft.v'
+	    '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) extraction/vard/coq/ExtractVarDRaft.v' \
+          -extra-phony 'distclean' 'clean' \
+	    'rm -f $$(join $$(dir $$(VFILES)),$$(addprefix .,$$(notdir $$(patsubst %.v,%.aux,$$(VFILES)))))'
 
 raft/RaftState.v:
 	$(PYTHON) script/extract_record_notation.py raft/RaftState.v.rec raft_data > raft/RaftState.v
 
 clean:
 	if [ -f Makefile.coq ]; then \
-	  $(MAKE) -f Makefile.coq cleanall; fi
-	rm -f Makefile.coq raft/RaftState.v
+	  $(MAKE) -f Makefile.coq distclean; fi
+	rm -f Makefile.coq raft/RaftState.v script/.assumptions.aux
 	find . -name '*.buildtime' -delete
 	$(MAKE) -C proofalytics clean
 	$(MAKE) -C extraction/vard clean

--- a/README.md
+++ b/README.md
@@ -11,19 +11,21 @@ Requirements
  - [`Coq 8.5`](https://coq.inria.fr/download)
  - [`Verdi`](https://github.com/uwplse/verdi)
  - [`StructTact`](https://github.com/uwplse/StructTact)
+ - [`verdi-runtime`](https://github.com/DistributedComponents/verdi-runtime)
 
 Building
 --------
 
 First run `./configure` in the root directory.  This will check
 for the appropriate version of Coq and ensure all necessary
-dependencies can be located. By default, it checks for `verdi` 
-and `StructTact` in the current parent directory, but this can be
-overridden by setting the `Verdi_PATH` and `StructTact_PATH` environment
-variables.
+Coq dependencies can be located. By default, `verdi` and `StructTact`
+are assumed to be installed in Coq's `user-contrib` directory, but
+this can be overridden by setting the `Verdi_PATH` and `StructTact_PATH`
+environment variables.
 
 Then run `make` in the root directory. This will compile the Raft 
-implementation and proof interfaces, and check all the proofs.
+implementation and proof interfaces, check all the proofs, and
+build the `vard` key-value store.
 
 Files
 -----
@@ -54,12 +56,6 @@ all proof interfaces to show Raft's *linearizability* property.
 
 The `vard` Key-Value Store
 ------------------------
-
-Requirements:
-
-- `Coq 8.5`
-- `OCaml 4.02`
-- `Ocamlbuild`
 
 `vard` is a simple key-value store implemented using
 Verdi. `vard` is specified and verified against Verdi's state-machine

--- a/configure
+++ b/configure
@@ -7,7 +7,5 @@ DEPS=(StructTact Verdi)
 DIRS=(raft raft-proofs extraction/vard/coq)
 CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft" "Verdi.Verdi" "Build Verdi before building Verdi Raft")
 EXTRA=(raft/RaftState.v)
-Verdi_PATH=$(perl -MCwd -e 'print Cwd::abs_path shift' ${Verdi_PATH:="../verdi"})
-Verdi_DIRS=(core lib systems extraction/coq)
+Verdi_DIRS=(core lib systems extraction)
 source script/coqproject.sh
-ln -sfn $Verdi_PATH/extraction/ocaml extraction/vard/lib

--- a/extraction/vard/Makefile
+++ b/extraction/vard/Makefile
@@ -1,22 +1,21 @@
 PYTHON=python2.7
 
-OCAMLBUILD = ocamlbuild -lib str -lib unix -I lib -I ml -cflag -g
-OCAMLBUILD_TEST = ocamlbuild -package oUnit -lib str -I lib -I ml -I test -cflag -g
+OCAMLBUILD = ocamlbuild -package verdi-runtime -I ml -cflag -g
+OCAMLBUILD_TEST = $(OCAMLBUILD) -package oUnit -I test
 
 VARDRAFT = ml/VarDRaft.ml ml/VarDRaft.mli
 VARD = ml/VarDArrangement.ml ml/vard.ml ml/VarDSerialization.ml
 VARD_TEST = test/OptsTest.ml test/TestCommon.ml test/VarDSerializationTest.ml test/VarDTest.ml
-LIB = lib/Shim.ml lib/Util.ml lib/Opts.ml
 
 default: vard.native
 
-vard.native: $(LIB) $(VARD) $(VARDRAFT)
+vard.native: $(VARD) $(VARDRAFT)
 	$(OCAMLBUILD) vard.native
 
 $(VARDRAFT):
 	+$(MAKE) -C ../.. extraction/vard/$@
 
-VarDTest.native: $(LIB) $(VARD) $(VARDRAFT) $(VARD_TEST)
+VarDTest.native: $(VARD) $(VARDRAFT) $(VARD_TEST)
 	$(OCAMLBUILD_TEST) VarDTest.native
 
 test-units: VarDTest.native

--- a/script/coqproject.sh
+++ b/script/coqproject.sh
@@ -24,24 +24,30 @@ function dep_dirs_lines(){
       namespace_var=${namespace_var//-/_}
       namespace_var=${namespace_var//./_}
       namespace=${!namespace_var:=$2}
-      LINE="-Q $1/$dep_dir/ $namespace"
+      if [ $dep_dir = "." ]; then
+        LINE="-Q $1 $namespace"
+      else
+	LINE="-Q $1/$dep_dir $namespace"
+      fi
       echo $LINE >> $COQPROJECT_TMP
   done
 }
 for dep in ${DEPS[@]}; do
     path_var="$dep"_PATH
-    path=${!path_var:="../$dep"}
-    if [ ! -d "$path" ]; then
-        echo "$dep not found at $path."
-        exit 1
+    if [ ! "x${!path_var}" = "x" ]; then
+	path=${!path_var}
+	if [ ! -d "$path" ]; then
+            echo "$dep not found at $path."
+            exit 1
+	fi
+
+	pushd "$path" > /dev/null
+	path=$(pwd)
+	popd > /dev/null
+	echo "$dep found at $path"
+
+	dep_dirs_lines $path $dep
     fi
-
-    pushd "$path" > /dev/null
-    path=$(pwd)
-    popd > /dev/null
-    echo "$dep found at $path"
-
-    dep_dirs_lines $path $dep
 done
 
 COQTOP="coqtop $(cat $COQPROJECT_TMP)"
@@ -64,13 +70,13 @@ for dir in ${DIRS[@]}; do
     namespace_var=${namespace_var//-/_}
     namespace_var=${namespace_var//./_}
     namespace=${!namespace_var:="\"\""}
-    LINE="-Q $dir/ $namespace"
+    LINE="-Q $dir $namespace"
     echo $LINE >> $COQPROJECT_TMP
 done
 
 for dir in ${DIRS[@]}; do
     echo >> $COQPROJECT_TMP
-    find $dir -iname '*.v'  >> $COQPROJECT_TMP
+    find $dir -iname '*.v' -not -name '*\#*'  >> $COQPROJECT_TMP
 done
 
 for extra in ${EXTRA[@]}; do


### PR DESCRIPTION
Switch to the separate OCaml [`verdi-runtime`](https://github.com/DistributedComponents/verdi-runtime) library instead of symlinking in shim-related OCaml files. Make sure build works with dependencies installed as OPAM packages.