### PR TITLE
check that cluster size >= 2 in vard

### DIFF
--- a/extraction/vard/ml/vard.ml
+++ b/extraction/vard/ml/vard.ml
@@ -17,7 +17,8 @@ let _ =
   in
   let _ =
     try
-      validate ()
+      validate ();
+      if length !cluster < 2 then raise (Arg.Bad "Cluster size must be two or greater")
     with Arg.Bad msg ->
       eprintf "%s: %s" Sys.argv.(0) msg;
       prerr_newline ();


### PR DESCRIPTION
This prevents the liveness issue reported by @tschottdorf that arises in singleton clusters - namely, that a node cannot elect itself leader without having received a `RequestVoteReply` message.