### PR TITLE
port to Coq 8.6

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -14,7 +14,7 @@ pushd ..
     ./build.sh $TARGET
   popd
 
-  git clone 'https://github.com/uwplse/verdi.git'
+  git clone -b coq-8.6 'https://github.com/uwplse/verdi.git'
   pushd verdi
     ./build.sh $TARGET
   popd

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -5,29 +5,23 @@ eval $(opam config env)
 
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam repo add distributedcomponents-dev http://opam-dev.distributedcomponents.net
+
 opam pin add coq $COQ_VERSION --yes --verbose
 opam pin add coq-mathcomp-ssreflect $SSREFLECT_VERSION --yes --verbose
-opam install StructTact InfSeqExt verdi-runtime --yes --verbose
-
-pushd ..
-  git clone -b coq-8.6 'https://github.com/uwplse/verdi.git'
-  pushd verdi
-    ./build.sh $TARGET
-  popd
-popd
+opam install StructTact verdi verdi-runtime --yes --verbose
 
 case $MODE in
   analytics)
-    Verdi_PATH=../verdi ./script/analytics.sh
+    ./script/analytics.sh
     ;;
   vard-quick)
-    Verdi_PATH=../verdi ./build.sh vard-quick
+    ./build.sh vard-quick
     ;;
   vard-test)
     opam install ounit.2.0.0 --yes --verbose
-    Verdi_PATH=../verdi ./build.sh vard-test
+    ./build.sh vard-test
     ;;
   *)
-    Verdi_PATH=../verdi ./build.sh $TARGET
+    ./build.sh $TARGET
     ;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ addons:
       - aspcud
 env:
   global:
-    - COQ_VERSION=8.5.3
-    - SSREFLECT_VERSION=1.6
+    - COQ_VERSION=8.6
+    - SSREFLECT_VERSION=1.6.1
   matrix:
     - MODE=build
       TARGET=default

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ Makefile.coq: raft/RaftState.v _CoqProject
 	    'extraction/vard/coq/ExtractVarDRaft.v extraction/vard/coq/VarDRaft.vo' \
 	    '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) extraction/vard/coq/ExtractVarDRaft.v' \
           -extra-phony 'distclean' 'clean' \
-	    'rm -f $$(join $$(dir $$(VFILES)),$$(addprefix .,$$(notdir $$(patsubst %.v,%.aux,$$(VFILES)))))'
+	    'rm -f $$(join $$(dir $$(VFILES)),$$(addprefix .,$$(notdir $$(patsubst %.v,%.vo.aux,$$(VFILES)))))'
 
 raft/RaftState.v:
 	$(PYTHON) script/extract_record_notation.py raft/RaftState.v.rec raft_data > raft/RaftState.v

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 PYTHON=python2.7
-COQVERSION := $(shell coqc --version|grep -E "version 8.(5|6)")
+COQVERSION := $(shell coqc --version|grep -E "version 8.6")
 
 ifeq "$(COQVERSION)" ""
-$(error "Verdi Raft is only compatible with Coq version 8.5 or 8.6")
+$(error "Verdi Raft is only compatible with Coq version 8.6")
 endif
 
 COQPROJECT_EXISTS=$(wildcard _CoqProject)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 PYTHON=python2.7
-COQVERSION := $(shell coqc --version|grep "version 8.5")
+COQVERSION := $(shell coqc --version|grep -E "version 8.(5|6)")
 
 ifeq "$(COQVERSION)" ""
-$(error "Verdi Raft is only compatible with Coq version 8.5")
+$(error "Verdi Raft is only compatible with Coq version 8.5 or 8.6")
 endif
 
 COQPROJECT_EXISTS=$(wildcard _CoqProject)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON=python2.7
-COQVERSION := $(shell coqc --version|grep -E "version 8.6")
+COQVERSION := $(shell coqc --version|grep "version 8.6")
 
 ifeq "$(COQVERSION)" ""
 $(error "Verdi Raft is only compatible with Coq version 8.6")

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Requirements
 
 Definitions and proofs:
 
-- [`Coq 8.5`](https://coq.inria.fr/coq-85)
+- [`Coq 8.6`](https://coq.inria.fr/coq-86)
 - [`Verdi`](https://github.com/uwplse/verdi)
 - [`StructTact`](https://github.com/uwplse/StructTact)
 
 Executable `vard` key-value store:
 
-- [`OCaml 4.02.3`](https://coq.inria.fr/download)
+- [`OCaml 4.02.3`](https://coq.inria.fr/download) (or later)
 - [`OCamlbuild`](https://github.com/ocaml/ocamlbuild)
 - [`verdi-runtime`](https://github.com/DistributedComponents/verdi-runtime)
 
@@ -38,7 +38,6 @@ We recommend installing the dependencies of Verdi Raft via
 ```
 opam repo add coq-released https://coq.inria.fr/opam/released
 opam repo add distributedcomponents-dev http://opam-dev.distributedcomponents.net
-opam pin add coq 8.5.3
 opam install verdi StructTact verdi-runtime ocamlbuild
 ```
 

--- a/raft-proofs/AllEntriesLeaderLogsTermProof.v
+++ b/raft-proofs/AllEntriesLeaderLogsTermProof.v
@@ -43,7 +43,7 @@ Section AllEntriesLeaderLogsTerm.
         eapply append_entries_leaderLogs_invariant in H; eauto
     end.
     break_exists. break_and. subst. do_in_app.
-    break_or_hyp; try find_apply_hyp_hyp; auto.
+    case H7; intros; try find_apply_hyp_hyp; auto.
     right.
     find_eapply_lem_hyp Prefix_In; eauto.
     repeat eexists; eauto.

--- a/raft-proofs/AllEntriesLogMatchingProof.v
+++ b/raft-proofs/AllEntriesLogMatchingProof.v
@@ -117,21 +117,21 @@ Section AllEntriesLogMatching.
 
   Lemma allEntries_log_matching_client_request :
     refined_raft_net_invariant_client_request allEntries_log_matching_inductive.
-  Proof using rlmli lsi aelsi rri. 
+  Proof using rlmli lsi aelsi rri.
     start_update.
     - subst.
       find_copy_apply_lem_hyp update_elections_data_client_request_log_allEntries.
       intuition; simpl in *; repeat find_rewrite; eauto.
       break_exists; intuition; repeat find_rewrite; simpl in *; intuition; subst; simpl in *; eauto.
+      + contradict_maxIndex.
       + enough (In e' (log (snd (nwState net h0)))) by 
             contradict_maxIndex.
         eapply allEntries_leader_sublog_invariant; repeat find_rewrite; eauto.
-      + contradict_maxIndex.
     - find_apply_lem_hyp update_elections_data_client_request_log_allEntries.
       intuition; simpl in *; repeat find_rewrite; eauto.
       break_exists. intuition; repeat find_rewrite; simpl in *; intuition; eauto.
       subst.
-      enough (In e (log (snd (nwState net h')))) by 
+      enough (In e (log (snd (nwState net h')))) by
             contradict_maxIndex.
       eapply lifted_leader_sublog_invariant; repeat find_rewrite; eauto.
     - find_apply_lem_hyp update_elections_data_client_request_log_allEntries.
@@ -238,7 +238,7 @@ Section AllEntriesLogMatching.
     intuition. repeat find_reverse_rewrite.
     eapply entries_contiguous_nw_invariant; eauto.
   Qed.
-  
+
   Lemma allEntries_log_matching_append_entries :
     refined_raft_net_invariant_append_entries allEntries_log_matching_inductive.
   Proof using rlmli. 
@@ -288,18 +288,37 @@ Section AllEntriesLogMatching.
       match goal with
         | H : context [handleAppendEntries] |- _ =>
           eapply update_elections_data_appendEntries_log_allEntries with (h' := n) in H
-      end ; intuition; repeat find_rewrite; simpl in *; intuition; subst; eauto;
-      try (find_rewrite_lem map_app; find_rewrite_lem map_map; simpl in *; find_rewrite_lem map_id;
-           do_in_app; intuition; eauto);
-      eauto using packets_entries_eq.
+      end.
+      intuition; repeat find_rewrite; simpl in *; subst; intuition; eauto.
+      + find_rewrite_lem map_app.
+        find_rewrite_lem map_map.
+        simpl in *.
+        find_rewrite_lem map_id.
+        apply in_app_or in H11.
+        intuition; eauto.
+        eauto using packets_entries_eq.
+      + find_rewrite_lem map_app.
+        find_rewrite_lem map_map.
+        simpl in *.
+        find_rewrite_lem map_id.
+        apply in_app_or in H11.
+        intuition; eauto.
+        eauto using packets_entries_eq.
+      + find_rewrite_lem map_app.
+        find_rewrite_lem map_map.
+        simpl in *.
+        find_rewrite_lem map_id.
+        apply in_app_or in H11.
+        intuition; eauto.
+        eauto using packets_entries_eq.
     - find_apply_hyp_hyp.
       intuition;
         [|exfalso; do_in_map; subst; simpl in *;
          eapply handleAppendEntries_not_append_entries; eauto;
          intuition; repeat find_rewrite; repeat eexists; eauto].
       eauto.
-  Qed.
-      
+Qed.
+
   Lemma allEntries_log_matching_append_entries_reply :
     refined_raft_net_invariant_append_entries_reply allEntries_log_matching_inductive.
   Proof using. 
@@ -321,7 +340,9 @@ Section AllEntriesLogMatching.
     exfalso; subst; simpl in *;
     subst;
     find_eapply_lem_hyp handleRequestVote_no_append_entries; eauto;
-    intuition; repeat find_rewrite; find_false; repeat eexists; eauto.
+    intuition; repeat find_rewrite; try (find_false; repeat eexists; eauto).
+    contradict H.
+    repeat eexists; eauto.
   Qed.
 
 

--- a/raft-proofs/AllEntriesLogProof.v
+++ b/raft-proofs/AllEntriesLogProof.v
@@ -292,7 +292,7 @@ Ltac all f ls :=
   Lemma allEntries_log_append_entries :
     refined_raft_net_invariant_append_entries allEntries_log.
   Proof using aetsi rri tsi llsi ollpti llci aellti rlmli aerlli llli. 
-    red. unfold allEntries_log in *. simpl in *. intros.
+  (*red. unfold allEntries_log in *. simpl in *. intros.
     repeat find_higher_order_rewrite.
     destruct_update; simpl in *;
     [|find_apply_hyp_hyp; intuition;
@@ -836,7 +836,8 @@ Ltac all f ls :=
               eapply entries_sorted_nw_invariant; eauto.
             - subst. intuition.
           }
-  Qed.
+  *)
+  Admitted.
 
   Lemma handleAppendEntriesReply_currentTerm_leaderId :
     forall h st h' t es res st' m,
@@ -951,7 +952,7 @@ Ltac all f ls :=
     red. unfold allEntries_log in *. intros. simpl in *.
     repeat find_higher_order_rewrite.
     destruct_update; simpl in *;
-    try (find_eapply_lem_hyp update_elections_data_client_request_allEntries'; eauto; [idtac]);
+    try (find_copy_eapply_lem_hyp update_elections_data_client_request_allEntries'; eauto; [idtac]);
     intuition;
     find_copy_apply_lem_hyp handleClientRequest_log;
     find_apply_lem_hyp handleClientRequest_currentTerm_leaderId;

--- a/raft-proofs/AllEntriesLogProof.v
+++ b/raft-proofs/AllEntriesLogProof.v
@@ -292,7 +292,7 @@ Ltac all f ls :=
   Lemma allEntries_log_append_entries :
     refined_raft_net_invariant_append_entries allEntries_log.
   Proof using aetsi rri tsi llsi ollpti llci aellti rlmli aerlli llli. 
-  (*red. unfold allEntries_log in *. simpl in *. intros.
+    red. unfold allEntries_log in *. simpl in *. intros.
     repeat find_higher_order_rewrite.
     destruct_update; simpl in *;
     [|find_apply_hyp_hyp; intuition;
@@ -317,7 +317,7 @@ Ltac all f ls :=
     - subst.
       find_copy_eapply_lem_hyp allEntries_term_sanity_invariant; eauto.
       destruct (lt_eq_lt_dec t0 (currentTerm d)); intuition; unfold ghost_data in *; simpl in *; try omega.
-      + find_eapply_lem_hyp append_entries_leaderLogs_invariant; eauto.
+      + eapply append_entries_leaderLogs_invariant in H1; eauto.
         break_exists. break_and.
         match goal with
           | H : In (?t, ?ll) (leaderLogs (fst (nwState _ ?leader))) |- _ =>
@@ -335,7 +335,8 @@ Ltac all f ls :=
         find_eapply_lem_hyp allEntries_leaderLogs_term_invariant; eauto. intuition.
         * subst. exfalso.
           find_copy_eapply_lem_hyp logs_leaderLogs_invariant; eauto.
-          find_copy_eapply_lem_hyp append_entries_leaderLogs_invariant; eauto.
+          pose proof H1 as H1'.
+          eapply append_entries_leaderLogs_invariant in H1; eauto.
           break_exists; intuition;
           [break_exists; intuition;
            find_eapply_lem_hyp leaderLogs_contiguous_invariant; eauto; omega|].
@@ -376,7 +377,8 @@ Ltac all f ls :=
           end; eauto using sorted_uniqueIndices.
           subst. auto.
         * exfalso.
-          find_copy_eapply_lem_hyp append_entries_leaderLogs_invariant; eauto.
+          pose proof H1 as H1'.
+          eapply append_entries_leaderLogs_invariant in H1; eauto.
           break_exists; intuition;
           [break_exists; intuition;
            find_eapply_lem_hyp leaderLogs_contiguous_invariant; eauto; omega|].
@@ -391,7 +393,7 @@ Ltac all f ls :=
     - subst.
       find_copy_eapply_lem_hyp allEntries_term_sanity_invariant; eauto.
       destruct (lt_eq_lt_dec t0 (currentTerm d)); intuition; unfold ghost_data in *; simpl in *; try omega.
-      + find_eapply_lem_hyp append_entries_leaderLogs_invariant; eauto.
+      + eapply append_entries_leaderLogs_invariant in H1; eauto.
         break_exists. break_and.
         match goal with
           | H : In (?t, ?ll) (leaderLogs (fst (nwState _ ?leader))) |- _ =>
@@ -410,7 +412,8 @@ Ltac all f ls :=
         find_eapply_lem_hyp allEntries_leaderLogs_term_invariant; eauto. intuition.
         * { subst. exfalso.
             find_copy_eapply_lem_hyp logs_leaderLogs_invariant; eauto.
-            find_copy_eapply_lem_hyp append_entries_leaderLogs_invariant; eauto.
+            pose proof H1 as H1'.
+            eapply append_entries_leaderLogs_invariant in H1; eauto.
             break_exists; intuition;
             [break_exists; intuition;
              find_eapply_lem_hyp leaderLogs_contiguous_invariant; eauto; omega|].
@@ -481,7 +484,8 @@ Ltac all f ls :=
                 subst. intuition.
           }
         * exfalso.
-          find_copy_eapply_lem_hyp append_entries_leaderLogs_invariant; eauto.
+          pose proof H1 as H1'.
+          eapply append_entries_leaderLogs_invariant in H1; eauto.
           break_exists; intuition;
           [break_exists; intuition;
            find_eapply_lem_hyp leaderLogs_contiguous_invariant; eauto; omega|].
@@ -509,7 +513,7 @@ Ltac all f ls :=
             destruct_update; simpl in *;
             eauto; rewrite update_elections_data_appendEntries_leaderLogs; eauto|];
           split; auto. intuition; subst.
-        * find_false.
+        * contradict n0.
           apply in_app_iff. right. eapply removeAfterIndex_le_In; eauto.
           find_eapply_lem_hyp leaderLogs_sorted_invariant; eauto.
           eapply le_trans; [eapply maxIndex_is_max; eauto|]. omega.
@@ -530,19 +534,20 @@ Ltac all f ls :=
                 find_copy_eapply_lem_hyp entries_sorted_nw_invariant; eauto.
                 eapply contiguous_app; eauto.
                 eapply entries_contiguous_nw_invariant; eauto.
-            - find_false.
+            - contradict n0.
               repeat find_rewrite.
               apply in_app_iff. right.
               find_eapply_lem_hyp leaderLogs_sorted_invariant; eauto.
               apply removeAfterIndex_le_In; auto.
               eapply maxIndex_is_max; eauto.
           }
-        * find_false. intuition.
+        * contradict n0. intuition.
       + subst.
         find_eapply_lem_hyp allEntries_leaderLogs_term_invariant; eauto. intuition.
         * { subst. exfalso.
             find_copy_eapply_lem_hyp logs_leaderLogs_invariant; eauto.
-            find_copy_eapply_lem_hyp append_entries_leaderLogs_invariant; eauto.
+            pose proof H1 as H1'.
+            eapply append_entries_leaderLogs_invariant in H1; eauto.
             break_exists. break_and.
             repeat find_rewrite.
             find_eapply_lem_hyp one_leaderLog_per_term_log_invariant; eauto.
@@ -725,7 +730,7 @@ Ltac all f ls :=
             destruct_update; simpl in *;
             eauto; rewrite update_elections_data_appendEntries_leaderLogs; eauto|];
           split; auto. intuition; subst.
-        * find_false.
+        * contradict n0.
           apply in_app_iff. right. eapply removeAfterIndex_le_In; eauto.
           find_eapply_lem_hyp leaderLogs_sorted_invariant; eauto.
           eapply le_trans; [eapply maxIndex_is_max; eauto|]. omega.
@@ -746,19 +751,20 @@ Ltac all f ls :=
                 find_copy_eapply_lem_hyp entries_sorted_nw_invariant; eauto.
                 eapply contiguous_app; eauto.
                 eapply entries_contiguous_nw_invariant; eauto.
-            - find_false.
+            - contradict n0.
               repeat find_rewrite.
               apply in_app_iff. right.
               find_eapply_lem_hyp leaderLogs_sorted_invariant; eauto.
               apply removeAfterIndex_le_In; auto.
               eapply maxIndex_is_max; eauto.
           }
-        * find_false. intuition.
+        * contradict n0. intuition.
       + subst.
         find_eapply_lem_hyp allEntries_leaderLogs_term_invariant; eauto. intuition.
         * { subst. exfalso.
             find_copy_eapply_lem_hyp logs_leaderLogs_invariant; eauto.
-            find_copy_eapply_lem_hyp append_entries_leaderLogs_invariant; eauto.
+            pose proof H1 as H1'.
+            eapply append_entries_leaderLogs_invariant in H1; eauto.
             break_exists. break_and.
             find_eapply_lem_hyp one_leaderLog_per_term_log_invariant; eauto.
             repeat find_rewrite.
@@ -836,8 +842,7 @@ Ltac all f ls :=
               eapply entries_sorted_nw_invariant; eauto.
             - subst. intuition.
           }
-  *)
-  Admitted.
+  Qed.
 
   Lemma handleAppendEntriesReply_currentTerm_leaderId :
     forall h st h' t es res st' m,

--- a/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
+++ b/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
@@ -437,7 +437,7 @@ Section AppendEntriesRequestLeaderLogs.
   Proof using. 
     induction l1; intros; simpl in *; intuition.
     subst. destruct l2; simpl in *; auto.
-    specialize (H2 e0); concludes; intuition.
+    specialize (H2 e0); conclude_using eauto; intuition.
   Qed.
 
   Lemma findGtIndex_Prefix :
@@ -479,7 +479,6 @@ Section AppendEntriesRequestLeaderLogs.
     - simpl in *. break_if; try congruence.
       do_bool. find_inversion. intuition.
   Qed.
-      
   
   Lemma append_entries_leaderLogs_doLeader :
     refined_raft_net_invariant_do_leader append_entries_leaderLogs.
@@ -547,12 +546,14 @@ Section AppendEntriesRequestLeaderLogs.
           break_exists_exists. exists nil.
           intuition; simpl in *; auto; eauto using sorted_app_in_1;
           [rewrite app_nil_r; auto|].
-          find_higher_order_rewrite. rewrite_update.
+          clear H18.
+          find_higher_order_rewrite.
+          rewrite_update.
           simpl in *. auto.
         * { find_copy_eapply_lem_hyp findGtIndex_app_in_2; eauto.
             exists x2. break_exists_exists.
             intuition; simpl in *; auto; intuition eauto.
-            - find_higher_order_rewrite. rewrite_update. auto.
+            - clear H18. find_higher_order_rewrite. rewrite_update. auto.
             - right. left. eexists; intuition; eauto.
               match goal with
                   | |- Prefix_sane ?l _ _ =>

--- a/raft-proofs/AppliedEntriesMonotonicProof.v
+++ b/raft-proofs/AppliedEntriesMonotonicProof.v
@@ -364,7 +364,9 @@ Section AppliedEntriesMonotonicProof.
     match goal with
       | |- context [update _ ?sigma ?h ?st] => pose proof applied_entries_update sigma h st
     end.
-    simpl in *. concludes. intuition.
+    simpl in *.
+    assert (commitIndex (sigma h) >= lastApplied (sigma h)) by omega.
+    concludes. intuition.
     - find_rewrite. eauto using app_nil_r.
     - pose proof applied_entries_cases sigma.
       intuition; repeat find_rewrite; eauto.

--- a/raft-proofs/GhostLogAllEntriesProof.v
+++ b/raft-proofs/GhostLogAllEntriesProof.v
@@ -64,7 +64,7 @@ Section GhostLogAllEntriesProof.
         break_exists_exists.
         eauto using update_elections_data_appendEntries_preserves_allEntries'.
       + remember (pSrc p0).
-        subst. simpl in *.
+        subst_max. simpl in *.
         unfold write_ghost_log in *.
         simpl in *.
         match goal with

--- a/raft-proofs/InputBeforeOutputProof.v
+++ b/raft-proofs/InputBeforeOutputProof.v
@@ -89,7 +89,9 @@ Section InputBeforeOutput.
     match goal with
       | |- context [update _ ?sigma ?h ?st] => pose proof applied_entries_update sigma h st
     end.
-    simpl in *. concludes. intuition; [find_rewrite; exists nil; simpl in *; intuition|].
+    simpl in *.
+    assert (commitIndex (sigma h) >= lastApplied (sigma h)) by omega.
+    concludes. intuition; [find_rewrite; exists nil; simpl in *; intuition|].
     pose proof applied_entries_cases sigma.
     intuition; repeat find_rewrite; eauto;
     [eexists; intuition; eauto;
@@ -514,7 +516,7 @@ Section InputBeforeOutput.
       unfold ghost_data in *. simpl in *.
       repeat find_rewrite.
       do_in_app. intuition.
-      + find_false. eexists; intuition; repeat find_rewrite; eauto.
+      + contradict H1. eexists; intuition; repeat find_rewrite; eauto.
       + find_apply_hyp_hyp. break_exists. intuition.
         eapply handleMessage_log with (h'' := x1); eauto;
         [destruct p; simpl in *; repeat find_rewrite; intuition|].

--- a/raft-proofs/LeaderLogsVotesWithLogProof.v
+++ b/raft-proofs/LeaderLogsVotesWithLogProof.v
@@ -162,7 +162,7 @@ Section LeaderLogsVotesWithLog.
     - subst.
       find_eapply_lem_hyp requestVoteReply_moreUpToDate_invariant; eauto.
       repeat find_rewrite.
-      repeat concludes.
+      repeat conclude_using eauto.
       break_exists_exists. intuition.
       find_higher_order_rewrite.
       simpl in *.

--- a/raft-proofs/LogMatchingProof.v
+++ b/raft-proofs/LogMatchingProof.v
@@ -289,7 +289,9 @@ Section LogMatchingProof.
                      _ : In ?x (log (_ _ ?leader)) |-
                      In ?x (log (_ _ ?h)) ] =>
                    specialize (Hentries leader h e1 e2 x)
-              end. repeat concludes. intuition.
+              end.
+              assert (eIndex x <= eIndex e1) by omega.
+              repeat conclude. intuition.
           }
     - use_packet_subset_clear; unfold log_matching in *; intuition.
       + unfold log_matching_nw in *; intuition. use_nw_invariant.

--- a/raft-proofs/LogsLeaderLogsProof.v
+++ b/raft-proofs/LogsLeaderLogsProof.v
@@ -205,7 +205,6 @@ Section LogsLeaderLogs.
     intros. pattern ll.
     eapply log_properties_hold_on_leader_logs_invariant; eauto using contiguous_log_property.
   Qed.
-
   
   Lemma logs_leaderLogs_inductive_appendEntries :
     refined_raft_net_invariant_append_entries logs_leaderLogs_inductive.
@@ -258,7 +257,7 @@ Section LogsLeaderLogs.
               prove_in.
               copy_eapply_prop_hyp In In; eauto.
               match goal with
-                | H:exists _, _ |- _ => destruct H as (leader)
+                | H:exists _, _ |- _ => destruct H as [leader]
               end.
               break_exists; intuition.
               + (* all of the new entries, as well as x, are in the
@@ -360,6 +359,7 @@ Section LogsLeaderLogs.
                             (apply removeAfterIndex_in with (i := index);
                              repeat find_rewrite; intuition)
                     end.
+                    clear H0 H7.
                     eapply_prop_hyp In In. omega.
                   } subst. simpl.
                   find_copy_eapply_lem_hyp leaderLogs_sorted_invariant; eauto.
@@ -657,9 +657,9 @@ Section LogsLeaderLogs.
             break_and. find_apply_hyp_hyp.
             match goal with
               | H : exists _ _ _, _ |- _ =>
-                destruct H as (leader);
-                  destruct H as (ll);
-                  destruct H as (es)
+                destruct H as [leader];
+                  destruct H as [ll];
+                  destruct H as [es]
             end.
             break_and.
             destruct (lt_eq_lt_dec (maxIndex ll) pli); intuition.

--- a/raft-proofs/MatchIndexAllEntriesProof.v
+++ b/raft-proofs/MatchIndexAllEntriesProof.v
@@ -489,12 +489,15 @@ Section MatchIndexAllEntries.
     find_copy_eapply_lem_hyp append_entries_leaderLogs_invariant; eauto.
     break_exists. break_and.
     subst es.
-    find_apply_lem_hyp in_app_or. break_or_hyp.
+    find_apply_lem_hyp in_app_or. destruct H4.
     - find_copy_apply_hyp_hyp.
-      eapply lifted_leader_sublog_nw; eauto. intuition.
+      eapply lifted_leader_sublog_nw; eauto; [subst; auto|auto with datatypes].
     - find_eapply_lem_hyp leaders_have_leaderLogs_strong_invariant; auto.
       break_exists.  break_and.
-      pose proof one_leaderLog_per_term_invariant _ ltac:(eauto) h x _ x3 x0 ltac:(eauto) ltac:(eauto).
+      pose proof one_leaderLog_per_term_invariant _ ltac:(eauto) h x (currentTerm (snd (nwState net h))) x3 x0.
+      concludes.
+      subst_max.
+      concludes.
       break_and. subst.
       find_rewrite. eauto using Prefix_In with *.
   Qed.
@@ -584,6 +587,7 @@ Section MatchIndexAllEntries.
                 | [ H : entries_match _ _ |- _ ] =>
                   specialize (H x x e)
                 end.
+                assert (eIndex e <= eIndex x) by omega.
                 repeat concludes. intuition.
               }
 

--- a/raft-proofs/OutputGreatestIdProof.v
+++ b/raft-proofs/OutputGreatestIdProof.v
@@ -159,10 +159,9 @@ Section OutputGreatestId.
             exfalso.
             unfold cacheApplyEntry, applyEntry in *.
             find_apply_lem_hyp has_key_true_necessary. intuition.
-            repeat break_match; repeat find_rewrite; find_inversion; do_bool; subst.
-            - find_eapply_lem_hyp applyEntries_cache; auto;
-              [eapply lt_trans; [|eauto]; eauto|idtac|]; eauto.
-            - find_eapply_lem_hyp applyEntries_cache; eauto.
+            repeat break_match; repeat find_rewrite; find_inversion; do_bool; subst_max.
+            - find_eapply_lem_hyp applyEntries_cache; eauto; omega.
+            - find_eapply_lem_hyp applyEntries_cache; eauto; omega.
             - find_eapply_lem_hyp applyEntries_cache; eauto;
               unfold getLastId in *; simpl in *; eauto using get_set_same.
             - find_eapply_lem_hyp applyEntries_cache; eauto;
@@ -170,17 +169,16 @@ Section OutputGreatestId.
           }
       + simpl in *. find_inversion.
         { destruct (has_key client id' a) eqn:?; eauto.
-            exfalso.
-            unfold cacheApplyEntry, applyEntry in *.
-            find_apply_lem_hyp has_key_true_necessary. intuition.
-            repeat break_match; repeat find_rewrite; find_inversion; do_bool; subst.
-            - find_eapply_lem_hyp applyEntries_cache; auto;
-              [eapply lt_trans; [|eauto]; eauto|idtac|]; eauto.
-            - find_eapply_lem_hyp applyEntries_cache; eauto.
-            - find_eapply_lem_hyp applyEntries_cache; eauto;
-              unfold getLastId in *; simpl in *; eauto using get_set_same.
-            - find_eapply_lem_hyp applyEntries_cache; eauto;
-              unfold getLastId in *; simpl in *; eauto using get_set_same.
+          exfalso.
+          unfold cacheApplyEntry, applyEntry in *.
+          find_apply_lem_hyp has_key_true_necessary. intuition.
+          repeat break_match; repeat find_rewrite; find_inversion; do_bool; subst.
+            - find_eapply_lem_hyp applyEntries_cache; eauto; omega.
+            - find_eapply_lem_hyp applyEntries_cache; eauto; omega.
+            - eapply applyEntries_cache in Heqp0; eauto;
+                unfold getLastId in *; simpl in *; eauto using get_set_same.
+            - eapply applyEntries_cache in Heqp0; eauto;
+                unfold getLastId in *; simpl in *; eauto using get_set_same.
           }
   Qed.
 
@@ -226,7 +224,7 @@ Section OutputGreatestId.
       id < id' ->
       before_func (has_key client id) (has_key client id') (applied_entries (update name_eq_dec (nwState net) h st')).
   Proof using lacimi smci si lmi. 
-    intros.
+  (*intros.
     find_copy_apply_lem_hyp logs_sorted_invariant.
     pose proof entries_contiguous.
     match goal with
@@ -309,7 +307,8 @@ Section OutputGreatestId.
             assert (y <= x) by omega
         end.
         eapply_prop_hyp le le; eauto. intuition.
-  Qed.
+  *)
+  Admitted.
 
   
   Lemma output_implies_greatest :

--- a/raft-proofs/OutputGreatestIdProof.v
+++ b/raft-proofs/OutputGreatestIdProof.v
@@ -224,7 +224,7 @@ Section OutputGreatestId.
       id < id' ->
       before_func (has_key client id) (has_key client id') (applied_entries (update name_eq_dec (nwState net) h st')).
   Proof using lacimi smci si lmi. 
-  (*intros.
+    intros.
     find_copy_apply_lem_hyp logs_sorted_invariant.
     pose proof entries_contiguous.
     match goal with
@@ -238,7 +238,9 @@ Section OutputGreatestId.
     unfold key_in_output_list in *.
     match goal with | H : exists _, _ |- _ => destruct H as [o] end.
     unfold doGenericServer in *. break_let. simpl in *.
-    find_inversion. simpl in *. find_copy_eapply_lem_hyp applyEntries_before; eauto.
+    find_inversion. simpl in *.
+    pose proof Heqp as Heqp'.
+    eapply applyEntries_before in Heqp; eauto.
     match goal with
       | H : before_func _ _ ?l |- _=>
         eapply before_func_prepend with
@@ -307,8 +309,7 @@ Section OutputGreatestId.
             assert (y <= x) by omega
         end.
         eapply_prop_hyp le le; eauto. intuition.
-  *)
-  Admitted.
+  Qed.
 
   
   Lemma output_implies_greatest :

--- a/raft-proofs/OutputImpliesAppliedProof.v
+++ b/raft-proofs/OutputImpliesAppliedProof.v
@@ -109,8 +109,10 @@ Section OutputImpliesApplied.
     intros. unfold key_in_output_list in *.
     match goal with | H : exists _, _ |- _ => destruct H as [o] end.
     unfold doGenericServer in *. break_let. simpl in *.
-    find_inversion. simpl in *. find_copy_eapply_lem_hyp applyEntries_In; eauto.
-    use_applyEntries_spec; subst; simpl in *.
+    find_inversion. simpl in *. 
+    pose proof Heqp as Happ.
+    find_eapply_lem_hyp applyEntries_In; eauto.
+    use_applyEntries_spec; subst_max; simpl in *.
     eexists; intuition eauto.
     find_apply_lem_hyp In_rev.
     find_apply_lem_hyp filter_In.

--- a/raft-proofs/PrefixWithinTermProof.v
+++ b/raft-proofs/PrefixWithinTermProof.v
@@ -968,8 +968,8 @@ Section PrefixWithinTerm.
                   destruct (lt_eq_lt_dec (eTerm e) (eTerm x))
               end; intuition; try omega.
               + exfalso.
-                find_eapply_lem_hyp append_entries_request_term_sanity_invariant; eauto.
-                conclude_using eauto. omega.
+                eapply append_entries_request_term_sanity_invariant in H1; eauto.
+                conclude_using eauto; omega.
               + apply in_app_iff. right.
                 apply removeAfterIndex_le_In; [omega|].
                 eapply_prop allEntries_log_prefix_within_term; eauto; omega.
@@ -1000,7 +1000,7 @@ Section PrefixWithinTerm.
                   destruct (lt_eq_lt_dec (eTerm e) (eTerm x))
               end; intuition; try omega.
               + exfalso.
-                find_eapply_lem_hyp append_entries_request_term_sanity_invariant; eauto.
+                eapply append_entries_request_term_sanity_invariant in H1; eauto.
                 conclude_using eauto. omega.
               + apply in_app_iff. right.
                 apply removeAfterIndex_le_In; [omega|].

--- a/raft-proofs/PrefixWithinTermProof.v
+++ b/raft-proofs/PrefixWithinTermProof.v
@@ -197,9 +197,9 @@ Section PrefixWithinTerm.
           assert (In x (removeAfterIndex l i)) by (apply removeAfterIndex_le_In; eauto; omega)
       end. subst.
       find_apply_hyp_hyp.
-      eapply entries_match_nw_1_invariant.
-      Focus 5. eauto. Focus 4. eauto. all:eauto; try omega. repeat find_rewrite; auto.
-      admit.
+      eapply entries_match_nw_1_invariant in H1; eauto.
+      apply H1; eauto.
+      repeat find_rewrite; auto.
     - break_exists. break_and.
       match goal with
         | H : _ \/ _ |- _ => clear H
@@ -730,7 +730,7 @@ Section PrefixWithinTerm.
           | H : removeAfterIndex _ _ = _ |- _ =>
             eapply removeAfterIndex_in; rewrite H; apply in_app_iff; [idtac]
         end. eauto using Prefix_In.
-  Admitted.
+  Qed.
   
   Definition log_leaderLogs_prefix_within_term net :=
     forall h t ll leader,

--- a/raft-proofs/PrefixWithinTermProof.v
+++ b/raft-proofs/PrefixWithinTermProof.v
@@ -87,7 +87,7 @@ Section PrefixWithinTerm.
     find_apply_hyp_hyp.
     find_apply_lem_hyp exists_deghosted_packet.
     match goal with
-      | H : exists _, _ |- _ => destruct H as (q)
+      | H : exists _, _ |- _ => destruct H as [q]
     end. break_and.
     match goal with
       | H : leader_sublog_nw_invariant _ |- _ =>
@@ -183,7 +183,7 @@ Section PrefixWithinTerm.
         | H : removeAfterIndex ?l ?index = ?es ++ ?ll |- _ =>
           eapply app_contiguous_maxIndex_le_eq in H
       end;
-        [|idtac|eapply removeAfterIndex_contiguous; [eapply entries_sorted_nw_invariant; eauto|eapply entries_contiguous_nw_invariant; eauto]|idtac]; eauto.
+        [|idtac|eapply removeAfterIndex_contiguous; [eapply entries_sorted_nw_invariant; eauto|eapply entries_contiguous_nw_invariant; eauto]|idtac]; eauto; [|omega].
       assert (exists e'', eIndex e'' = eIndex e /\ In e'' es') by
           (eapply entries_contiguous_nw_invariant; eauto; intuition;
        eapply le_trans; eauto;
@@ -199,6 +199,7 @@ Section PrefixWithinTerm.
       find_apply_hyp_hyp.
       eapply entries_match_nw_1_invariant.
       Focus 5. eauto. Focus 4. eauto. all:eauto; try omega. repeat find_rewrite; auto.
+      admit.
     - break_exists. break_and.
       match goal with
         | H : _ \/ _ |- _ => clear H
@@ -729,7 +730,7 @@ Section PrefixWithinTerm.
           | H : removeAfterIndex _ _ = _ |- _ =>
             eapply removeAfterIndex_in; rewrite H; apply in_app_iff; [idtac]
         end. eauto using Prefix_In.
-  Qed.
+  Admitted.
   
   Definition log_leaderLogs_prefix_within_term net :=
     forall h t ll leader,

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -75,8 +75,8 @@ Section RaftMsgRefinement.
       msg_refined_raft_net_invariant_reboot P ->
       msg_refined_raft_intermediate_reachable net ->
       P net.
-  Proof using. 
-    intros.
+  Proof using.
+  (*intros.
     induction H10.
     - intuition.
     -  match goal with [H : step_failure _ _ _ |- _ ] => invcs H end.
@@ -277,7 +277,8 @@ Section RaftMsgRefinement.
     - eapply msg_refined_raft_invariant_handle_message; eauto.
     - eapply_prop msg_refined_raft_net_invariant_do_leader; eauto.
     - eapply_prop msg_refined_raft_net_invariant_do_generic_server; eauto.
-  Qed.
+  *)
+  Admitted.
 
   Lemma msg_refined_raft_invariant_handle_message' P :
     forall xs p ys net st' ps' gd d l,
@@ -343,7 +344,7 @@ Section RaftMsgRefinement.
       msg_refined_raft_intermediate_reachable net ->
       P net.
   Proof using. 
-    intros.
+  (*intros.
     induction H10.
     - intuition.
     -  match goal with [H : step_failure _ _ _ |- _ ] => invcs H end.
@@ -549,7 +550,8 @@ Section RaftMsgRefinement.
       eapply MRRIR_doLeader; eauto.
     - eapply_prop msg_refined_raft_net_invariant_do_generic_server'; eauto.
       eapply MRRIR_doGenericServer; eauto.
-  Qed.
+  *)
+  Admitted.
 
   Ltac workhorse :=
     try match goal with

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -76,7 +76,7 @@ Section RaftMsgRefinement.
       msg_refined_raft_intermediate_reachable net ->
       P net.
   Proof using.
-  (*intros.
+    intros.
     induction H10.
     - intuition.
     -  match goal with [H : step_failure _ _ _ |- _ ] => invcs H end.
@@ -122,7 +122,7 @@ Section RaftMsgRefinement.
          eauto.
          simpl. eapply in_app_or.
          simpl.
-         {
+         { clear H11.
            match goal with
              | H : msg_refined_raft_intermediate_reachable ?net |-
                msg_refined_raft_intermediate_reachable ?net' =>
@@ -210,7 +210,7 @@ Section RaftMsgRefinement.
          eauto.
          simpl. eapply in_app_or.
          simpl.
-         {
+         { clear H11.
            match goal with
              | H : msg_refined_raft_intermediate_reachable ?net |-
                msg_refined_raft_intermediate_reachable ?net' =>
@@ -277,8 +277,7 @@ Section RaftMsgRefinement.
     - eapply msg_refined_raft_invariant_handle_message; eauto.
     - eapply_prop msg_refined_raft_net_invariant_do_leader; eauto.
     - eapply_prop msg_refined_raft_net_invariant_do_generic_server; eauto.
-  *)
-  Admitted.
+  Qed.
 
   Lemma msg_refined_raft_invariant_handle_message' P :
     forall xs p ys net st' ps' gd d l,
@@ -344,7 +343,7 @@ Section RaftMsgRefinement.
       msg_refined_raft_intermediate_reachable net ->
       P net.
   Proof using. 
-  (*intros.
+    intros.
     induction H10.
     - intuition.
     -  match goal with [H : step_failure _ _ _ |- _ ] => invcs H end.
@@ -393,7 +392,7 @@ Section RaftMsgRefinement.
               try solve [in_crush];
               simpl in *; intros; repeat break_if; try congruence; auto).
          subst.
-         eapply_prop msg_refined_raft_net_invariant_do_generic_server'. eauto.
+         (*eapply_prop msg_refined_raft_net_invariant_do_generic_server'. eauto.
          eapply_prop msg_refined_raft_net_invariant_do_leader'. eauto.
          eapply msg_refined_raft_invariant_handle_message' with (P := P); auto.
          eauto. eauto.   auto. eauto.  eauto. eauto using in_app_or. auto.
@@ -435,7 +434,8 @@ Section RaftMsgRefinement.
            simpl in *.
            rewrite map_map.
            apply in_map_iff.
-           eexists; intuition; eauto.
+           eexists; intuition; eauto.*)
+         admit.
        + match goal with 
          | [ H : msg_refined_raft_intermediate_reachable _ |- _ ?x ] => 
            assert (msg_refined_raft_intermediate_reachable x) as Hpost
@@ -482,6 +482,7 @@ Section RaftMsgRefinement.
               try solve [in_crush];
               simpl in *; intros; repeat break_if; try congruence; auto).
          subst.
+         (*
          eapply_prop msg_refined_raft_net_invariant_do_generic_server'. eauto.
          eapply_prop msg_refined_raft_net_invariant_do_leader'. eauto.
          eapply msg_refined_raft_invariant_handle_input' with (P := P); auto.
@@ -523,7 +524,8 @@ Section RaftMsgRefinement.
            simpl in *.
            rewrite map_map.
            apply in_map_iff.
-           eexists; intuition; eauto.
+           eexists; intuition; eauto.*)
+         admit.
        + match goal with
            | [ H : nwPackets ?net = _ |- _ {| nwPackets := ?ps ; nwState := ?st |} ] =>
              assert (forall p, In p (nwPackets {| nwPackets := ps ; nwState := st |}) ->
@@ -550,7 +552,6 @@ Section RaftMsgRefinement.
       eapply MRRIR_doLeader; eauto.
     - eapply_prop msg_refined_raft_net_invariant_do_generic_server'; eauto.
       eapply MRRIR_doGenericServer; eauto.
-  *)
   Admitted.
 
   Ltac workhorse :=

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -373,7 +373,7 @@ Section RaftMsgRefinement.
                                        (@add_ghost_msg _ _ _ ghost_log_params (pDst p)
                                                        (post_ghost_state, r0) l4);
                 nwState := update name_eq_dec (nwState net) (pDst p)
-                                  (post_ghost_state, r0) |})
+                                  (post_ghost_state, r0) |}) as Hr0
            by (subst; eapply MRRIR_handleMessage; eauto; in_crush).
          assert
            (msg_refined_raft_intermediate_reachable
@@ -387,16 +387,16 @@ Section RaftMsgRefinement.
                                        (@add_ghost_msg _ _ _ ghost_log_params (pDst p)
                                                        (post_ghost_state, r1) l5);
                 nwState := update name_eq_dec (nwState net) (pDst p)
-                                  (post_ghost_state, r1) |}) by
+                                  (post_ghost_state, r1) |}) as Hr1 by
              (eapply MRRIR_doLeader; eauto;
               try solve [in_crush];
               simpl in *; intros; repeat break_if; try congruence; auto).
          subst.
-         (*eapply_prop msg_refined_raft_net_invariant_do_generic_server'. eauto.
+         eapply_prop msg_refined_raft_net_invariant_do_generic_server'. eauto.
          eapply_prop msg_refined_raft_net_invariant_do_leader'. eauto.
          eapply msg_refined_raft_invariant_handle_message' with (P := P); auto.
          eauto. eauto.   auto. eauto.  eauto. eauto using in_app_or. auto.
-         eauto.
+         exact Hr1.
          simpl. break_if; intuition eauto.
          simpl. intros. break_if; intuition eauto.
          simpl. in_crush. auto. auto.
@@ -434,9 +434,8 @@ Section RaftMsgRefinement.
            simpl in *.
            rewrite map_map.
            apply in_map_iff.
-           eexists; intuition; eauto.*)
-         admit.
-       + match goal with 
+           eexists; intuition; eauto.
+       + match goal with
          | [ H : msg_refined_raft_intermediate_reachable _ |- _ ?x ] => 
            assert (msg_refined_raft_intermediate_reachable x) as Hpost
                   by (eapply MRRIR_step_failure; eauto; eapply StepFailure_input; eauto)
@@ -463,7 +462,7 @@ Section RaftMsgRefinement.
                                        (@add_ghost_msg _ _ _ ghost_log_params h
                                                        (post_ghost_state, r0) l4);
                 nwState := update name_eq_dec (nwState net) h
-                                  (post_ghost_state, r0) |})
+                                  (post_ghost_state, r0) |}) as Hr0
            by (subst; eapply MRRIR_handleInput; eauto; in_crush).
          assert
            (msg_refined_raft_intermediate_reachable
@@ -477,17 +476,16 @@ Section RaftMsgRefinement.
                                        (@add_ghost_msg _ _ _ ghost_log_params h
                                                        (post_ghost_state, r1) l6);
                 nwState := update name_eq_dec (nwState net) h
-                                  (post_ghost_state, r1) |}) by
+                                  (post_ghost_state, r1) |}) as Hr1 by
              (eapply MRRIR_doLeader; eauto;
               try solve [in_crush];
               simpl in *; intros; repeat break_if; try congruence; auto).
          subst.
-         (*
          eapply_prop msg_refined_raft_net_invariant_do_generic_server'. eauto.
          eapply_prop msg_refined_raft_net_invariant_do_leader'. eauto.
          eapply msg_refined_raft_invariant_handle_input' with (P := P); auto.
          eauto. eauto.   auto. eauto.  eauto. eauto using in_app_or. auto.
-         eauto.
+         exact Hr1.
          simpl. break_if; intuition eauto.
          simpl. intros. break_if; intuition eauto.
          simpl. in_crush. auto. auto.
@@ -524,8 +522,7 @@ Section RaftMsgRefinement.
            simpl in *.
            rewrite map_map.
            apply in_map_iff.
-           eexists; intuition; eauto.*)
-         admit.
+           eexists; intuition; eauto.
        + match goal with
            | [ H : nwPackets ?net = _ |- _ {| nwPackets := ?ps ; nwState := ?st |} ] =>
              assert (forall p, In p (nwPackets {| nwPackets := ps ; nwState := st |}) ->
@@ -552,7 +549,7 @@ Section RaftMsgRefinement.
       eapply MRRIR_doLeader; eauto.
     - eapply_prop msg_refined_raft_net_invariant_do_generic_server'; eauto.
       eapply MRRIR_doGenericServer; eauto.
-  Admitted.
+  Qed.
 
   Ltac workhorse :=
     try match goal with

--- a/raft-proofs/RequestVoteReplyMoreUpToDateProof.v
+++ b/raft-proofs/RequestVoteReplyMoreUpToDateProof.v
@@ -72,7 +72,7 @@ Section RequestVoteReplyMoreUpToDate.
         break_exists_exists. intuition.
         eauto using update_elections_data_request_vote_votesWithLog_old.
       + remember (pSrc p0) as h.
-        subst. simpl in *. subst.
+        subst_max. simpl in *. subst_max.
         find_copy_apply_lem_hyp handleRequestVote_reply_true.
         find_eapply_lem_hyp update_elections_data_request_vote_votedFor; eauto;
         intuition; eauto; repeat find_rewrite.
@@ -90,7 +90,7 @@ Section RequestVoteReplyMoreUpToDate.
         repeat find_rewrite.
         eapply_prop_hyp pBody pBody; eauto.
       + remember (pDst p0) as h.
-        subst. simpl in *. subst.
+        subst_max. simpl in *. subst_max.
         find_copy_apply_lem_hyp handleRequestVote_reply_true. intuition.
     - find_apply_hyp_hyp; intuition.
       + assert (In p0 (nwPackets net)) by (repeat find_rewrite; in_crush).

--- a/raft-proofs/StateMachineSafetyPrimeProof.v
+++ b/raft-proofs/StateMachineSafetyPrimeProof.v
@@ -225,7 +225,9 @@ Section StateMachineSafety'.
       eIndex e' < eIndex e.
   Proof using. 
     intros; induction l1; simpl in *; intuition.
-    subst. specialize (H2 e'). concludes. intuition.
+    subst_max. specialize (H2 e').
+    assert (In e' (l1 ++ l2)) by auto with datatypes.
+    concludes. intuition.
   Qed.
 
   Lemma Prefix_In :
@@ -251,6 +253,8 @@ Section StateMachineSafety'.
   Proof using. 
     destruct l; simpl; intuition congruence.
   Qed.
+
+  Set Bullet Behavior "Strict Subproofs".
 
   Theorem state_machine_safety_nw'_invariant :
     forall net,
@@ -308,6 +312,7 @@ Section StateMachineSafety'.
             find_apply_lem_hyp (@maxIndex_is_max _ _ x2 e); eauto.
             omega.
           }
+          pose proof H1 as Happ.
           find_copy_eapply_lem_hyp entries_contiguous; eauto.
           eapply contiguous_app; eauto. eapply entries_sorted_nw_invariant; eauto.
         * cut (e = x5); [intros; subst; intuition|].

--- a/raft-proofs/StateMachineSafetyProof.v
+++ b/raft-proofs/StateMachineSafetyProof.v
@@ -2007,7 +2007,7 @@ Section StateMachineSafetyProof.
                        unfold msg_log_property in *.
                        specialize (Hprop (fun l => forall e, In e l -> eIndex e > 0) p).
                        conclude_using ltac:(intros; eapply lifted_entries_gt_0_invariant; eauto).
-                       concludes. simpl in *.
+                       conclude_using eauto. simpl in *.
                        find_apply_hyp_hyp.
                        omega.
                    }
@@ -2140,7 +2140,9 @@ Section StateMachineSafetyProof.
                          pose proof ghost_log_entries_match_invariant _ ltac:(eauto) (pDst p) _ ltac:(eauto)
                            as Hem.
                          specialize (Hem ple gple e').
-                         repeat concludes. intuition.
+                         repeat concludes.
+                         assert (eIndex e' <= eIndex ple) by omega.
+                         intuition.
                        }
                        subst.
 

--- a/raft/CommonTheorems.v
+++ b/raft/CommonTheorems.v
@@ -1475,10 +1475,18 @@ Section CommonTheorems.
     forall i a,
       contiguous_range_exact_lo [a] i ->
       eIndex a = S i.
-  Proof using. 
+  Proof using.
     intros. unfold contiguous_range_exact_lo in *. intuition.
-    find_insterU. concludes. find_insterU. concludes. break_exists.
-    simpl in *. intuition. subst. auto.
+    specialize (H1 a).
+    specialize (H0 (S i)).
+    assert (H_a: In a [a]) by auto with datatypes.
+    concludes.
+    assert (H_s: i < S i) by auto.
+    concludes.
+    break_exists.
+    break_and.
+    inversion H0; subst; auto.
+    inversion H2.
   Qed.
 
   Lemma contiguous_index_adjacent :

--- a/raft/CommonTheorems.v
+++ b/raft/CommonTheorems.v
@@ -1681,12 +1681,25 @@ Section CommonTheorems.
     - contradiction.
     - simpl Prefix in *. intuition. subst a. f_equal. break_if.
       + do_bool. unfold contiguous_range_exact_lo in *.
-        intuition. find_insterU. simpl in *. conclude_using eauto.
+        intuition.
+        simpl maxIndex in *.
+        specialize (H6 e).
+        specialize (H4 e).
+        assert (H_in': In e (e :: l')).
+          left. reflexivity.
+        concludes.
+        assert (H_in: In e (e :: l)).
+          left. reflexivity.
+        concludes.
         omega.
       + destruct l.
         { do_bool. simpl in *. find_apply_lem_hyp contiguous_index_singleton. destruct l'.
           - reflexivity.
-          - simpl. intuition. find_insterU. concludes. intuition. find_rewrite. break_if.
+          - simpl. intuition. specialize (H0 e0).
+            assert (H_in: In e0 (e0 :: l')).
+              left.
+              reflexivity.
+            concludes. intuition. find_rewrite. break_if.
             + reflexivity.
             + do_bool. omega. }
         { apply IHl; try discriminate; auto.
@@ -1694,9 +1707,33 @@ Section CommonTheorems.
             + firstorder.
             + eauto using Prefix_cons, prefix_sorted.
           - find_apply_lem_hyp cons_contiguous_sorted.
-            + firstorder.
+            + unfold contiguous_range_exact_lo in *.
+              inversion H1.
+              split; intros.
+              * do_bool.
+                simpl maxIndex in *.
+                destruct H2.
+                destruct H3.
+                destruct l'; simpl in *; intuition.
+                subst_max.
+                specialize (H2 i0).
+                specialize (H0 e1).
+                conclude_using eauto.
+                break_and.
+                assert (i < i0 <= eIndex e) by omega.
+                concludes.
+                break_exists.
+                break_and.
+                subst.
+                exists x.
+                split; auto.
+                break_or_hyp; auto.
+                omega.
+              * apply H2.
+                right; auto.
             + eauto using Prefix_cons, prefix_sorted.
-          - apply cons_contiguous_sorted in H3; auto. }
+          - apply cons_contiguous_sorted in H3; auto.
+       }
   Qed.
 
   Lemma thing :
@@ -1769,7 +1806,7 @@ Section CommonTheorems.
   Proof using. 
     induction l1; intros; simpl in *; intuition.
     subst. destruct l2; simpl in *; auto.
-    specialize (H2 e0); concludes; intuition.
+    specialize (H2 e0); conclude_using eauto; intuition.
   Qed.
 
   Lemma findGtIndex_Prefix :
@@ -2273,7 +2310,7 @@ Section CommonTheorems.
     intros l1.
     induction l1 using rev_ind; intuition.
     induction l2 using rev_ind.
-    - find_insterU. concludes. contradiction.
+    - find_insterU. conclude_using eauto. contradiction.
     - repeat rewrite rev_unit.
       find_apply_lem_hyp contiguous_sorted_last; auto.
       find_apply_lem_hyp contiguous_sorted_last; auto.

--- a/raft/RaftLinearizableProofs.v
+++ b/raft/RaftLinearizableProofs.v
@@ -974,7 +974,7 @@ Section RaftLinearizableProofs.
         rewrite <- app_ass.
         rewrite log_to_IR_app.
         simpl.
-        specialize (H x). concludes.
+        specialize (H x). conclude_using eauto.
         specialize (H0 l [] x l0 d).
         break_match; subst; simpl in *.
         rewrite app_nil_r.
@@ -1201,8 +1201,12 @@ Section RaftLinearizableProofs.
         find_apply_lem_hyp app_inv_head. find_inversion.
         unfold execute_log in *.
         find_rewrite_lem execute_log'_app. simpl in *.
-        repeat break_let. repeat find_inversion.
+        repeat break_let.
+        find_inversion.
+        find_inversion.
         rewrite rev_app_distr in *. simpl in *.
+        find_injection.
+        find_injection.
         unfold value in *. find_inversion.
         repeat find_rewrite. find_inversion. auto.
   Qed.


### PR DESCRIPTION
Fix proofs written for 8.5 that fail in 8.6 (not always completely cleanly). Restrict to 8.6 only. Verdi's Travis script needs to be adjusted after this is merged. To avoid making permanent a long and silly history, this should be squash-merged.