### PR TITLE
Set up OPAM package

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -8,17 +8,18 @@ opam repo add distributedcomponents-dev http://opam-dev.distributedcomponents.ne
 
 opam pin add coq $COQ_VERSION --yes --verbose
 opam pin add coq-mathcomp-ssreflect $SSREFLECT_VERSION --yes --verbose
-opam install StructTact verdi verdi-runtime --yes --verbose
+opam install StructTact verdi --yes --verbose
 
 case $MODE in
   analytics)
     ./script/analytics.sh
     ;;
-  vard-quick)
-    ./build.sh vard-quick
+  vard)
+    opam install verdi-runtime --yes --verbose
+    ./build.sh vard
     ;;
   vard-test)
-    opam install ounit.2.0.0 --yes --verbose
+    opam install verdi-runtime ounit.2.0.0 --yes --verbose
     ./build.sh vard-test
     ;;
   *)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 
 default: Makefile.coq
 	$(MAKE) -f Makefile.coq
-	+$(MAKE) -C extraction/vard
+#	+$(MAKE) -C extraction/vard
 
 quick: Makefile.coq
 	$(MAKE) -f Makefile.coq quick
@@ -64,9 +64,9 @@ clean:
 	$(MAKE) -C proofalytics clean
 	$(MAKE) -C extraction/vard clean
 
-vard:
-	@echo "To build everything (including vard) use the default target."
-	@echo "To quickly provision vard use the vard-quick target."
+vard: vard-quick
+#	@echo "To build everything (including vard) use the default target."
+#	@echo "To quickly provision vard use the vard-quick target."
 
 $(MLFILES): Makefile.coq
 	$(MAKE) -f Makefile.coq $@

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON=python2.7
-COQVERSION := $(shell coqc --version|grep "version 8.6")
+COQVERSION := $(shell coqc --version|egrep "version (8\\.5|8\\.6|trunk)")
 
 ifeq "$(COQVERSION)" ""
 $(error "Verdi Raft is only compatible with Coq version 8.6")
@@ -24,6 +24,9 @@ default: Makefile.coq
 quick: Makefile.coq
 	$(MAKE) -f Makefile.coq quick
 
+install: Makefile.coq
+	$(MAKE) -f Makefile.coq install
+
 proofalytics:
 	$(MAKE) -C proofalytics clean
 	$(MAKE) -C proofalytics
@@ -39,8 +42,8 @@ proofalytics-aux: Makefile.coq
 
 MLFILES = extraction/vard/ml/VarDRaft.ml extraction/vard/ml/VarDRaft.mli
 
-Makefile.coq: raft/RaftState.v _CoqProject
-	coq_makefile -f _CoqProject -o Makefile.coq -no-install \
+Makefile.coq: _CoqProject
+	coq_makefile -f _CoqProject -o Makefile.coq \
 	  -extra 'script/assumptions.vo script/assumptions.glob script/assumptions.v.d' \
 	    'script/assumptions.v raft-proofs/EndToEndLinearizability.vo' \
 	    '$$(COQC) $$(COQDEBUG) $$(COQFLAGS) script/assumptions.v' \
@@ -50,13 +53,13 @@ Makefile.coq: raft/RaftState.v _CoqProject
           -extra-phony 'distclean' 'clean' \
 	    'rm -f $$(join $$(dir $$(VFILES)),$$(addprefix .,$$(notdir $$(patsubst %.v,%.vo.aux,$$(VFILES)))))'
 
-raft/RaftState.v:
+raft/RaftState.v: raft/RaftState.v.rec
 	$(PYTHON) script/extract_record_notation.py raft/RaftState.v.rec raft_data > raft/RaftState.v
 
 clean:
 	if [ -f Makefile.coq ]; then \
 	  $(MAKE) -f Makefile.coq distclean; fi
-	rm -f Makefile.coq raft/RaftState.v script/.assumptions.aux
+	rm -f Makefile.coq script/.assumptions.aux
 	find . -name '*.buildtime' -delete
 	$(MAKE) -C proofalytics clean
 	$(MAKE) -C extraction/vard clean
@@ -81,4 +84,4 @@ lint:
 distclean: clean
 	rm -f _CoqProject
 
-.PHONY: default quick clean vard vard-quick vard-test lint proofalytics distclean $(MLFILES)
+.PHONY: default quick install clean vard vard-quick vard-test lint proofalytics distclean $(MLFILES)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ endif
 
 default: Makefile.coq
 	$(MAKE) -f Makefile.coq
-#	+$(MAKE) -C extraction/vard
 
 quick: Makefile.coq
 	$(MAKE) -f Makefile.coq quick
@@ -59,19 +58,15 @@ raft/RaftState.v: raft/RaftState.v.rec
 clean:
 	if [ -f Makefile.coq ]; then \
 	  $(MAKE) -f Makefile.coq distclean; fi
-	rm -f Makefile.coq script/.assumptions.aux
+	rm -f Makefile.coq script/.assumptions.vo.aux
 	find . -name '*.buildtime' -delete
 	$(MAKE) -C proofalytics clean
 	$(MAKE) -C extraction/vard clean
 
-vard: vard-quick
-#	@echo "To build everything (including vard) use the default target."
-#	@echo "To quickly provision vard use the vard-quick target."
-
 $(MLFILES): Makefile.coq
 	$(MAKE) -f Makefile.coq $@
 
-vard-quick:
+vard:
 	+$(MAKE) -C extraction/vard
 
 vard-test:
@@ -84,4 +79,4 @@ lint:
 distclean: clean
 	rm -f _CoqProject
 
-.PHONY: default quick install clean vard vard-quick vard-test lint proofalytics distclean $(MLFILES)
+.PHONY: default quick install clean vard vard-test lint proofalytics distclean $(MLFILES)

--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ this can be overridden by setting the `Verdi_PATH` and `StructTact_PATH`
 environment variables.
 
 Finally, run `make` in the root directory. This will compile the Raft
-implementation and proof interfaces, check all the proofs, and
-build the `vard` key-value store program in `extaction/vard`.
+implementation and proof interfaces, and check all the proofs.
 
-Alternatively, `make vard-quick` in the root directory builds `vard`
-without checking any proofs.
+To build the `vard` key-value store program in `extraction/vard`,
+run `make vard` in the root directory. If the implementation has
+been compiled as above, this simply extracts code to OCaml and
+compiles the result to a native program; otherwise, the implementation
+Coq code is compiled without checking any proofs.
 
 Files
 -----
@@ -91,11 +93,9 @@ semantics in the `VarD.v` example system distributed with Verdi. When the Raft t
 is applied, `vard` can be run as a strongly-consistent, fault-tolerant key-value store
 along the lines of [`etcd`](https://github.com/coreos/etcd).
 
-By default, after running `make` in the root directory, OCaml code for `vard`
+After running `make vard` in the root directory, OCaml code for `vard`
 is extracted, compiled, and linked against a Verdi shim and some `vard`-specific
 serialization/debugging code, to produce a `vard.native` binary in `extraction/vard`.
-The binary can also be produced without checking the correctness proofs by running
-`make vard-quick` in the root directory or simply `make` in `extraction/vard`.
 
 Running `make bench-vard` in `extraction/vard` will produce some 
 benchmark numbers, which are largely meaningless on

--- a/configure
+++ b/configure
@@ -5,6 +5,10 @@
 ## Configuration options for coqproject.sh
 DEPS=(StructTact Verdi)
 DIRS=(raft raft-proofs systems extraction/vard/coq)
+NAMESPACE_raft="VerdiRaft"
+NAMESPACE_raft_proofs="VerdiRaft"
+NAMESPACE_systems="VerdiRaft"
+NAMESPACE_extraction_vard_coq="VerdiRaft"
 CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft" "Verdi.Verdi" "Build Verdi before building Verdi Raft")
 EXTRA=(raft/RaftState.v)
 Verdi_DIRS=(core lib systems extraction)

--- a/configure
+++ b/configure
@@ -9,7 +9,6 @@ NAMESPACE_raft="VerdiRaft"
 NAMESPACE_raft_proofs="VerdiRaft"
 NAMESPACE_systems="VerdiRaft"
 NAMESPACE_extraction_vard_coq="VerdiRaft"
-CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft" "Verdi.Verdi" "Build Verdi before building Verdi Raft")
-EXTRA=(raft/RaftState.v)
+CANARIES=("mathcomp.ssreflect.ssreflect" "Verdi Raft requires ssreflect in mathcomp to be installed" "StructTact.StructTactics" "Build StructTact before building Verdi Raft" "Verdi.Verdi" "Build Verdi before building Verdi Raft")
 Verdi_DIRS=(core lib systems extraction)
 source script/coqproject.sh

--- a/descr
+++ b/descr
@@ -1,0 +1,1 @@
+Verdi Raft is a verified implementation of the Raft distributed consensus protocol in Coq.

--- a/extraction/vard/coq/ExtractVarDRaft.v
+++ b/extraction/vard/coq/ExtractVarDRaft.v
@@ -1,6 +1,6 @@
 Require Import Verdi.Verdi.
 Require Import Verdi.VarD.
-Require Import VarDRaft.
+Require Import VerdiRaft.VarDRaft.
 
 Require Import ExtrOcamlBasic.
 Require Import ExtrOcamlNatInt.

--- a/opam
+++ b/opam
@@ -1,0 +1,36 @@
+opam-version: "1.2"
+name: "verdi-raft"
+version: "dev"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/uwplse/verdi-raft"
+dev-repo: "https://github.com/uwplse/verdi-raft.git"
+bug-reports: "https://github.com/uwplse/verdi-raft/issues"
+license: "BSD"
+
+build: [
+  [ "./configure" ]
+  [ make "-j%{jobs}%" ]
+]
+install: [ make install ]
+remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/VerdiRaft'" ]
+depends: [
+  "coq" {(>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~") | (= "dev")}
+  "verdi" {= "dev"}
+  "StructTact" {= "dev"}
+]
+tags: [
+  "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
+  "keyword:program verification"
+  "keyword:distributed algorithms"
+  "keyword:raft"
+]
+authors: [
+  "James Wilcox <>"
+  "Doug Woos <>"
+  "Pavel Panchekha <>"
+  "Zachary Tatlock <>"
+  "Steve Anton <>"
+  "Karl Palmskog <>"
+  "Ryan Doenges <>"
+]

--- a/opam
+++ b/opam
@@ -15,7 +15,7 @@ build: [
 install: [ make install ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/VerdiRaft'" ]
 depends: [
-  "coq" {(>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~") | (= "dev")}
+  "coq" {((>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~"))}
   "verdi" {= "dev"}
   "StructTact" {= "dev"}
 ]

--- a/raft-proofs/AllEntriesCandidateEntriesProof.v
+++ b/raft-proofs/AllEntriesCandidateEntriesProof.v
@@ -1,20 +1,20 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
-Require Import RefinementCommonTheorems.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.RefinementCommonTheorems.
 
-Require Import CandidateEntriesInterface.
-Require Import CroniesCorrectInterface.
-Require Import CroniesTermInterface.
-Require Import AllEntriesTermSanityInterface.
+Require Import VerdiRaft.CandidateEntriesInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.CroniesTermInterface.
+Require Import VerdiRaft.AllEntriesTermSanityInterface.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
-Require Import AllEntriesCandidateEntriesInterface.
+Require Import VerdiRaft.AllEntriesCandidateEntriesInterface.
 
 Section AllEntriesCandidateEntries.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/AllEntriesIndicesGt0Proof.v
+++ b/raft-proofs/AllEntriesIndicesGt0Proof.v
@@ -1,15 +1,15 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import TermsAndIndicesFromOneLogInterface.
+Require Import VerdiRaft.TermsAndIndicesFromOneLogInterface.
 
-Require Import AllEntriesIndicesGt0Interface.
+Require Import VerdiRaft.AllEntriesIndicesGt0Interface.
 
 Section AllEntriesIndicesGt0.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/AllEntriesLeaderLogsProof.v
+++ b/raft-proofs/AllEntriesLeaderLogsProof.v
@@ -1,20 +1,20 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import CommonTheorems.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import AppendEntriesRequestLeaderLogsInterface.
-Require Import OneLeaderLogPerTermInterface.
-Require Import LeaderLogsSortedInterface.
-Require Import RefinedLogMatchingLemmasInterface.
-Require Import AppendEntriesRequestsCameFromLeadersInterface.
-Require Import AllEntriesLogInterface.
-Require Import LeaderSublogInterface.
-Require Import LeadersHaveLeaderLogsStrongInterface.
+Require Import VerdiRaft.AppendEntriesRequestLeaderLogsInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.LeaderLogsSortedInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.AppendEntriesRequestsCameFromLeadersInterface.
+Require Import VerdiRaft.AllEntriesLogInterface.
+Require Import VerdiRaft.LeaderSublogInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsStrongInterface.
 
-Require Import AllEntriesLeaderLogsInterface.
+Require Import VerdiRaft.AllEntriesLeaderLogsInterface.
 
 Section AllEntriesLeaderLogs.
 

--- a/raft-proofs/AllEntriesLeaderLogsTermProof.v
+++ b/raft-proofs/AllEntriesLeaderLogsTermProof.v
@@ -1,13 +1,13 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import RaftRefinementInterface.
-Require Import RefinementSpecLemmas.
-Require Import SpecLemmas.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RefinementSpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import AllEntriesLeaderLogsTermInterface.
-Require Import AppendEntriesRequestLeaderLogsInterface.
+Require Import VerdiRaft.AllEntriesLeaderLogsTermInterface.
+Require Import VerdiRaft.AppendEntriesRequestLeaderLogsInterface.
 
 Section AllEntriesLeaderLogsTerm.
 

--- a/raft-proofs/AllEntriesLeaderSublogProof.v
+++ b/raft-proofs/AllEntriesLeaderSublogProof.v
@@ -1,21 +1,21 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import RefinementCommonTheorems.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.RefinementCommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import AllEntriesLeaderSublogInterface.
+Require Import VerdiRaft.AllEntriesLeaderSublogInterface.
 
-Require Import CandidateEntriesInterface.
-Require Import AllEntriesCandidateEntriesInterface.
-Require Import VotesCorrectInterface.
-Require Import CroniesCorrectInterface.
-Require Import LeaderSublogInterface.
-Require Import OneLeaderPerTermInterface.
+Require Import VerdiRaft.CandidateEntriesInterface.
+Require Import VerdiRaft.AllEntriesCandidateEntriesInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.LeaderSublogInterface.
+Require Import VerdiRaft.OneLeaderPerTermInterface.
 
 Section AllEntriesLeaderSublog.
 

--- a/raft-proofs/AllEntriesLogMatchingProof.v
+++ b/raft-proofs/AllEntriesLogMatchingProof.v
@@ -1,17 +1,17 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
-Require Import RefinementCommonTheorems.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.RefinementCommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import AllEntriesLeaderSublogInterface.
-Require Import LeaderSublogInterface.
-Require Import RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.AllEntriesLeaderSublogInterface.
+Require Import VerdiRaft.LeaderSublogInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
 
-Require Import AllEntriesLogMatchingInterface.
+Require Import VerdiRaft.AllEntriesLogMatchingInterface.
 
 Section AllEntriesLogMatching.
 

--- a/raft-proofs/AllEntriesLogProof.v
+++ b/raft-proofs/AllEntriesLogProof.v
@@ -1,24 +1,24 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
-Require Import LogsLeaderLogsInterface.
-Require Import AppendEntriesRequestLeaderLogsInterface.
-Require Import RefinedLogMatchingLemmasInterface.
-Require Import AllEntriesLeaderLogsTermInterface.
-Require Import LeaderLogsContiguousInterface.
-Require Import OneLeaderLogPerTermInterface.
-Require Import LeaderLogsSortedInterface.
-Require Import TermSanityInterface.
-Require Import AllEntriesTermSanityInterface.
+Require Import VerdiRaft.LogsLeaderLogsInterface.
+Require Import VerdiRaft.AppendEntriesRequestLeaderLogsInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.AllEntriesLeaderLogsTermInterface.
+Require Import VerdiRaft.LeaderLogsContiguousInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.LeaderLogsSortedInterface.
+Require Import VerdiRaft.TermSanityInterface.
+Require Import VerdiRaft.AllEntriesTermSanityInterface.
 
-Require Import AllEntriesLogInterface.
+Require Import VerdiRaft.AllEntriesLogInterface.
 
 Section AllEntriesLog.
 

--- a/raft-proofs/AllEntriesTermSanityProof.v
+++ b/raft-proofs/AllEntriesTermSanityProof.v
@@ -1,11 +1,11 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import AllEntriesTermSanityInterface.
+Require Import VerdiRaft.AllEntriesTermSanityInterface.
 
 Section AllEntriesTermSanity.
 

--- a/raft-proofs/AllEntriesVotesWithLogProof.v
+++ b/raft-proofs/AllEntriesVotesWithLogProof.v
@@ -1,17 +1,17 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import RaftRefinementInterface.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
-Require Import AllEntriesVotesWithLogInterface.
-Require Import AllEntriesLogInterface.
-Require Import VotesWithLogTermSanityInterface.
-Require Import VotesCorrectInterface.
-Require Import VotesVotesWithLogCorrespondInterface.
+Require Import VerdiRaft.AllEntriesVotesWithLogInterface.
+Require Import VerdiRaft.AllEntriesLogInterface.
+Require Import VerdiRaft.VotesWithLogTermSanityInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.VotesVotesWithLogCorrespondInterface.
 
 Section AllEntriesVotesWithLog.
 

--- a/raft-proofs/AppendEntriesLeaderProof.v
+++ b/raft-proofs/AppendEntriesLeaderProof.v
@@ -1,17 +1,17 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import CommonTheorems.
-Require Import SpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import AppendEntriesRequestsCameFromLeadersInterface.
-Require Import OneLeaderLogPerTermInterface.
-Require Import LeaderLogsTermSanityInterface.
-Require Import OneLeaderPerTermInterface.
+Require Import VerdiRaft.AppendEntriesRequestsCameFromLeadersInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.LeaderLogsTermSanityInterface.
+Require Import VerdiRaft.OneLeaderPerTermInterface.
 
-Require Import AppendEntriesLeaderInterface.
+Require Import VerdiRaft.AppendEntriesLeaderInterface.
 
 Section AppendEntriesLeader.
 

--- a/raft-proofs/AppendEntriesReplySublogProof.v
+++ b/raft-proofs/AppendEntriesReplySublogProof.v
@@ -1,12 +1,12 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
-Require Import AppendEntriesReplySublogInterface.
+Require Import VerdiRaft.AppendEntriesReplySublogInterface.
 
-Require Import AppendEntriesRequestReplyCorrespondenceInterface.
-Require Import RaftRefinementInterface.
-Require Import AppendEntriesLeaderInterface.
+Require Import VerdiRaft.AppendEntriesRequestReplyCorrespondenceInterface.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.AppendEntriesLeaderInterface.
 
 Section AppendEntriesReplySublog.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
+++ b/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
@@ -1,16 +1,16 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonTheorems.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import LeadersHaveLeaderLogsStrongInterface.
-Require Import SortedInterface.
-Require Import LogMatchingInterface.
-Require Import AppendEntriesRequestLeaderLogsInterface.
-Require Import NextIndexSafetyInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsStrongInterface.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.AppendEntriesRequestLeaderLogsInterface.
+Require Import VerdiRaft.NextIndexSafetyInterface.
 
 Section AppendEntriesRequestLeaderLogs.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
+++ b/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
@@ -1,11 +1,11 @@
 Require Import FunctionalExtensionality.
 
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
-Require Import AppendEntriesRequestReplyCorrespondenceInterface.
+Require Import VerdiRaft.AppendEntriesRequestReplyCorrespondenceInterface.
 
 Require Import Verdi.DupDropReordering.
 

--- a/raft-proofs/AppendEntriesRequestTermSanityProof.v
+++ b/raft-proofs/AppendEntriesRequestTermSanityProof.v
@@ -1,10 +1,10 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import SortedInterface.
-Require Import AppendEntriesRequestTermSanityInterface.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.AppendEntriesRequestTermSanityInterface.
 
 Section AppendEntriesRequestTermSanity.
 

--- a/raft-proofs/AppendEntriesRequestsCameFromLeadersProof.v
+++ b/raft-proofs/AppendEntriesRequestsCameFromLeadersProof.v
@@ -1,12 +1,12 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import LeadersHaveLeaderLogsInterface.
-Require Import AppendEntriesRequestsCameFromLeadersInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsInterface.
+Require Import VerdiRaft.AppendEntriesRequestsCameFromLeadersInterface.
 
 Section AppendEntriesRequestsCameFromLeaders.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/AppliedEntriesMonotonicProof.v
+++ b/raft-proofs/AppliedEntriesMonotonicProof.v
@@ -1,22 +1,22 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import CommonTheorems.
-Require Import StateMachineSafetyInterface.
-Require Import SortedInterface.
-Require Import UniqueIndicesInterface.
-Require Import LogMatchingInterface.
-Require Import MaxIndexSanityInterface.
-Require Import CommitRecordedCommittedInterface.
-Require Import LeaderCompletenessInterface.
-Require Import LastAppliedCommitIndexMatchingInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.StateMachineSafetyInterface.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.UniqueIndicesInterface.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.MaxIndexSanityInterface.
+Require Import VerdiRaft.CommitRecordedCommittedInterface.
+Require Import VerdiRaft.LeaderCompletenessInterface.
+Require Import VerdiRaft.LastAppliedCommitIndexMatchingInterface.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import AppliedEntriesMonotonicInterface.
+Require Import VerdiRaft.AppliedEntriesMonotonicInterface.
 
 Section AppliedEntriesMonotonicProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/AppliedImpliesInputProof.v
+++ b/raft-proofs/AppliedImpliesInputProof.v
@@ -1,15 +1,15 @@
 Require Import Verdi.InverseTraceRelations.
 
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import TraceUtil.
-Require Import OutputImpliesAppliedInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.TraceUtil.
+Require Import VerdiRaft.OutputImpliesAppliedInterface.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import AppliedImpliesInputInterface.
+Require Import VerdiRaft.AppliedImpliesInputInterface.
 
 Section AppliedImpliesInputProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/CandidateEntriesProof.v
+++ b/raft-proofs/CandidateEntriesProof.v
@@ -1,19 +1,19 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import CommonTheorems.
-Require Import CroniesCorrectInterface.
-Require Import VotesCorrectInterface.
-Require Import TermSanityInterface.
-Require Import CroniesTermInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.TermSanityInterface.
+Require Import VerdiRaft.CroniesTermInterface.
 
-Require Import RefinementCommonTheorems.
+Require Import VerdiRaft.RefinementCommonTheorems.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import CandidateEntriesInterface.
+Require Import VerdiRaft.CandidateEntriesInterface.
 
 Section CandidateEntriesProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/CandidateTermGtLogProof.v
+++ b/raft-proofs/CandidateTermGtLogProof.v
@@ -1,10 +1,10 @@
-Require Import Raft.
-Require Import SpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import TermSanityInterface.
-Require Import CandidateTermGtLogInterface.
+Require Import VerdiRaft.TermSanityInterface.
+Require Import VerdiRaft.CandidateTermGtLogInterface.
 
 Section CandidateTermGtLog.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/CandidatesVoteForSelvesProof.v
+++ b/raft-proofs/CandidatesVoteForSelvesProof.v
@@ -1,7 +1,7 @@
-Require Import Raft.
-Require Import CommonTheorems.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import CandidatesVoteForSelvesInterface.
+Require Import VerdiRaft.CandidatesVoteForSelvesInterface.
 
 Section CandidatesVoteForSelvesProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/CausalOrderPreservedProof.v
+++ b/raft-proofs/CausalOrderPreservedProof.v
@@ -1,13 +1,13 @@
 Require Import Verdi.TraceRelations.
 
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.TraceUtil.
 
-Require Import CausalOrderPreservedInterface.
-Require Import OutputImpliesAppliedInterface.
-Require Import AppliedImpliesInputInterface.
-Require Import AppliedEntriesMonotonicInterface.
+Require Import VerdiRaft.CausalOrderPreservedInterface.
+Require Import VerdiRaft.OutputImpliesAppliedInterface.
+Require Import VerdiRaft.AppliedImpliesInputInterface.
+Require Import VerdiRaft.AppliedEntriesMonotonicInterface.
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 
 Section CausalOrderPreserved.

--- a/raft-proofs/CroniesCorrectProof.v
+++ b/raft-proofs/CroniesCorrectProof.v
@@ -1,11 +1,11 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CandidatesVoteForSelvesInterface.
-Require Import CommonTheorems.
-Require Import VotesCorrectInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CandidatesVoteForSelvesInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.VotesCorrectInterface.
 
-Require Import CroniesCorrectInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
 
 Section CroniesCorrectProof.
 

--- a/raft-proofs/CroniesTermProof.v
+++ b/raft-proofs/CroniesTermProof.v
@@ -1,11 +1,11 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import CommonTheorems.
+Require Import VerdiRaft.CommonTheorems.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import CroniesTermInterface.
+Require Import VerdiRaft.CroniesTermInterface.
 
 Section CroniesTermProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/CurrentTermGtZeroProof.v
+++ b/raft-proofs/CurrentTermGtZeroProof.v
@@ -1,9 +1,9 @@
-Require Import Raft.
-Require Import SpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import CurrentTermGtZeroInterface.
+Require Import VerdiRaft.CurrentTermGtZeroInterface.
 
 Section CurrentTermGtZero.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/EndToEndLinearizability.v
+++ b/raft-proofs/EndToEndLinearizability.v
@@ -1,279 +1,279 @@
-Require Import Raft.
-Require Import Linearizability.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.Linearizability.
 
-Require Import RaftLinearizableProofs.
+Require Import VerdiRaft.RaftLinearizableProofs.
 
-Require Import OutputCorrectInterface.
-Require Import OutputCorrectProof.
+Require Import VerdiRaft.OutputCorrectInterface.
+Require Import VerdiRaft.OutputCorrectProof.
 
-Require Import InputBeforeOutputInterface.
-Require Import InputBeforeOutputProof.
+Require Import VerdiRaft.InputBeforeOutputInterface.
+Require Import VerdiRaft.InputBeforeOutputProof.
 
-Require Import CausalOrderPreservedInterface.
-Require Import CausalOrderPreservedProof.
+Require Import VerdiRaft.CausalOrderPreservedInterface.
+Require Import VerdiRaft.CausalOrderPreservedProof.
 
-Require Import AppliedImpliesInputInterface.
-Require Import AppliedImpliesInputProof.
+Require Import VerdiRaft.AppliedImpliesInputInterface.
+Require Import VerdiRaft.AppliedImpliesInputProof.
 
-Require Import OutputImpliesAppliedInterface.
-Require Import OutputImpliesAppliedProof.
+Require Import VerdiRaft.OutputImpliesAppliedInterface.
+Require Import VerdiRaft.OutputImpliesAppliedProof.
 
-Require Import LogMatchingInterface.
-Require Import LogMatchingProof.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.LogMatchingProof.
 
-Require Import SortedInterface.
-Require Import SortedProof.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.SortedProof.
 
-Require Import TermSanityInterface.
-Require Import TermSanityProof.
+Require Import VerdiRaft.TermSanityInterface.
+Require Import VerdiRaft.TermSanityProof.
 
-Require Import LeaderSublogInterface.
-Require Import LeaderSublogProof.
+Require Import VerdiRaft.LeaderSublogInterface.
+Require Import VerdiRaft.LeaderSublogProof.
 
-Require Import RaftRefinementInterface.
-Require Import RaftRefinementProof.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RaftRefinementProof.
 
-Require Import CandidateEntriesInterface.
-Require Import CandidateEntriesProof.
+Require Import VerdiRaft.CandidateEntriesInterface.
+Require Import VerdiRaft.CandidateEntriesProof.
 
-Require Import CroniesTermInterface.
-Require Import CroniesTermProof.
+Require Import VerdiRaft.CroniesTermInterface.
+Require Import VerdiRaft.CroniesTermProof.
 
-Require Import CroniesCorrectInterface.
-Require Import CroniesCorrectProof.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.CroniesCorrectProof.
 
-Require Import VotesLeCurrentTermInterface.
-Require Import VotesLeCurrentTermProof.
+Require Import VerdiRaft.VotesLeCurrentTermInterface.
+Require Import VerdiRaft.VotesLeCurrentTermProof.
 
-Require Import VotesCorrectInterface.
-Require Import VotesCorrectProof.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.VotesCorrectProof.
 
-Require Import CandidatesVoteForSelvesInterface.
-Require Import CandidatesVoteForSelvesProof.
+Require Import VerdiRaft.CandidatesVoteForSelvesInterface.
+Require Import VerdiRaft.CandidatesVoteForSelvesProof.
 
-Require Import OneLeaderPerTermInterface.
-Require Import OneLeaderPerTermProof.
+Require Import VerdiRaft.OneLeaderPerTermInterface.
+Require Import VerdiRaft.OneLeaderPerTermProof.
 
-Require Import UniqueIndicesInterface.
-Require Import UniqueIndicesProof.
+Require Import VerdiRaft.UniqueIndicesInterface.
+Require Import VerdiRaft.UniqueIndicesProof.
 
-Require Import AppliedEntriesMonotonicInterface.
-Require Import AppliedEntriesMonotonicProof.
+Require Import VerdiRaft.AppliedEntriesMonotonicInterface.
+Require Import VerdiRaft.AppliedEntriesMonotonicProof.
 
-Require Import StateMachineSafetyInterface.
-Require Import StateMachineSafetyProof.
+Require Import VerdiRaft.StateMachineSafetyInterface.
+Require Import VerdiRaft.StateMachineSafetyProof.
 
-Require Import MaxIndexSanityInterface.
+Require Import VerdiRaft.MaxIndexSanityInterface.
 
-Require Import LeaderCompletenessInterface.
-Require Import LeaderCompletenessProof.
+Require Import VerdiRaft.LeaderCompletenessInterface.
+Require Import VerdiRaft.LeaderCompletenessProof.
 
-Require Import TransitiveCommitInterface.
-Require Import TransitiveCommitProof.
+Require Import VerdiRaft.TransitiveCommitInterface.
+Require Import VerdiRaft.TransitiveCommitProof.
 
-Require Import AllEntriesLeaderLogsInterface.
-Require Import AllEntriesLeaderLogsProof.
+Require Import VerdiRaft.AllEntriesLeaderLogsInterface.
+Require Import VerdiRaft.AllEntriesLeaderLogsProof.
 
-Require Import CommitRecordedCommittedInterface.
+Require Import VerdiRaft.CommitRecordedCommittedInterface.
 
-Require Import LeaderLogsTermSanityInterface.
-Require Import LeaderLogsTermSanityProof.
+Require Import VerdiRaft.LeaderLogsTermSanityInterface.
+Require Import VerdiRaft.LeaderLogsTermSanityProof.
 
 
-Require Import AllEntriesTermSanityInterface.
-Require Import AllEntriesTermSanityProof.
+Require Import VerdiRaft.AllEntriesTermSanityInterface.
+Require Import VerdiRaft.AllEntriesTermSanityProof.
 
-Require Import VotesWithLogTermSanityInterface.
-Require Import VotesWithLogTermSanityProof.
+Require Import VerdiRaft.VotesWithLogTermSanityInterface.
+Require Import VerdiRaft.VotesWithLogTermSanityProof.
 
-Require Import LeaderLogsPreservedInterface.
-Require Import LeaderLogsPreservedProof.
+Require Import VerdiRaft.LeaderLogsPreservedInterface.
+Require Import VerdiRaft.LeaderLogsPreservedProof.
 
-Require Import PrefixWithinTermInterface.
-Require Import PrefixWithinTermProof.
+Require Import VerdiRaft.PrefixWithinTermInterface.
+Require Import VerdiRaft.PrefixWithinTermProof.
 
-Require Import EveryEntryWasCreatedInterface.
-Require Import EveryEntryWasCreatedProof.
+Require Import VerdiRaft.EveryEntryWasCreatedInterface.
+Require Import VerdiRaft.EveryEntryWasCreatedProof.
 
-Require Import EveryEntryWasCreatedHostLogInterface.
-Require Import EveryEntryWasCreatedHostLogProof.
+Require Import VerdiRaft.EveryEntryWasCreatedHostLogInterface.
+Require Import VerdiRaft.EveryEntryWasCreatedHostLogProof.
 
-Require Import LeaderLogsVotesWithLogInterface.
-Require Import LeaderLogsVotesWithLogProof.
+Require Import VerdiRaft.LeaderLogsVotesWithLogInterface.
+Require Import VerdiRaft.LeaderLogsVotesWithLogProof.
 
-Require Import AllEntriesLogInterface.
-Require Import AllEntriesLogProof.
+Require Import VerdiRaft.AllEntriesLogInterface.
+Require Import VerdiRaft.AllEntriesLogProof.
 
-Require Import AllEntriesVotesWithLogInterface.
-Require Import AllEntriesVotesWithLogProof.
+Require Import VerdiRaft.AllEntriesVotesWithLogInterface.
+Require Import VerdiRaft.AllEntriesVotesWithLogProof.
 
-Require Import VotesWithLogSortedInterface.
-Require Import VotesWithLogSortedProof.
+Require Import VerdiRaft.VotesWithLogSortedInterface.
+Require Import VerdiRaft.VotesWithLogSortedProof.
 
-Require Import LeaderLogsLogMatchingInterface.
-Require Import LeaderLogsLogMatchingProof.
+Require Import VerdiRaft.LeaderLogsLogMatchingInterface.
+Require Import VerdiRaft.LeaderLogsLogMatchingProof.
 
-Require Import StateMachineSafetyPrimeInterface.
-Require Import StateMachineSafetyPrimeProof.
+Require Import VerdiRaft.StateMachineSafetyPrimeInterface.
+Require Import VerdiRaft.StateMachineSafetyPrimeProof.
 
-Require Import AppendEntriesRequestLeaderLogsInterface.
-Require Import AppendEntriesRequestLeaderLogsProof.
+Require Import VerdiRaft.AppendEntriesRequestLeaderLogsInterface.
+Require Import VerdiRaft.AppendEntriesRequestLeaderLogsProof.
 
-Require Import AppendEntriesRequestsCameFromLeadersInterface.
-Require Import AppendEntriesRequestsCameFromLeadersProof.
+Require Import VerdiRaft.AppendEntriesRequestsCameFromLeadersInterface.
+Require Import VerdiRaft.AppendEntriesRequestsCameFromLeadersProof.
 
-Require Import LeaderLogsSortedInterface.
-Require Import LeaderLogsSortedProof.
+Require Import VerdiRaft.LeaderLogsSortedInterface.
+Require Import VerdiRaft.LeaderLogsSortedProof.
 
-Require Import LeaderLogsContiguousInterface.
-Require Import LeaderLogsContiguousProof.
+Require Import VerdiRaft.LeaderLogsContiguousInterface.
+Require Import VerdiRaft.LeaderLogsContiguousProof.
 
-Require Import LogsLeaderLogsInterface.
-Require Import LogsLeaderLogsProof.
+Require Import VerdiRaft.LogsLeaderLogsInterface.
+Require Import VerdiRaft.LogsLeaderLogsProof.
 
-Require Import OneLeaderLogPerTermInterface.
-Require Import OneLeaderLogPerTermProof.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermProof.
 
-Require Import LeaderLogsSublogInterface.
-Require Import LeaderLogsSublogProof.
+Require Import VerdiRaft.LeaderLogsSublogInterface.
+Require Import VerdiRaft.LeaderLogsSublogProof.
 
-Require Import LeadersHaveLeaderLogsInterface.
-Require Import LeadersHaveLeaderLogsProof.
+Require Import VerdiRaft.LeadersHaveLeaderLogsInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsProof.
 
-Require Import LeadersHaveLeaderLogsStrongInterface.
-Require Import LeadersHaveLeaderLogsStrongProof.
+Require Import VerdiRaft.LeadersHaveLeaderLogsStrongInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsStrongProof.
 
-Require Import NextIndexSafetyInterface.
-Require Import NextIndexSafetyProof.
+Require Import VerdiRaft.NextIndexSafetyInterface.
+Require Import VerdiRaft.NextIndexSafetyProof.
 
-Require Import RefinedLogMatchingLemmasInterface.
-Require Import RefinedLogMatchingLemmasProof.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasProof.
 
-Require Import LeaderLogsCandidateEntriesInterface.
-Require Import LeaderLogsCandidateEntriesProof.
+Require Import VerdiRaft.LeaderLogsCandidateEntriesInterface.
+Require Import VerdiRaft.LeaderLogsCandidateEntriesProof.
 
-Require Import AllEntriesCandidateEntriesInterface.
-Require Import AllEntriesCandidateEntriesProof.
+Require Import VerdiRaft.AllEntriesCandidateEntriesInterface.
+Require Import VerdiRaft.AllEntriesCandidateEntriesProof.
 
-Require Import AllEntriesLogMatchingInterface.
-Require Import AllEntriesLogMatchingProof.
+Require Import VerdiRaft.AllEntriesLogMatchingInterface.
+Require Import VerdiRaft.AllEntriesLogMatchingProof.
 
-Require Import AppendEntriesRequestTermSanityInterface.
-Require Import AppendEntriesRequestTermSanityProof.
+Require Import VerdiRaft.AppendEntriesRequestTermSanityInterface.
+Require Import VerdiRaft.AppendEntriesRequestTermSanityProof.
 
-Require Import AllEntriesLeaderSublogInterface.
-Require Import AllEntriesLeaderSublogProof.
+Require Import VerdiRaft.AllEntriesLeaderSublogInterface.
+Require Import VerdiRaft.AllEntriesLeaderSublogProof.
 
-Require Import LastAppliedCommitIndexMatchingInterface.
-Require Import LastAppliedCommitIndexMatchingProof.
+Require Import VerdiRaft.LastAppliedCommitIndexMatchingInterface.
+Require Import VerdiRaft.LastAppliedCommitIndexMatchingProof.
 
-Require Import LastAppliedLeCommitIndexInterface.
-Require Import LastAppliedLeCommitIndexProof.
+Require Import VerdiRaft.LastAppliedLeCommitIndexInterface.
+Require Import VerdiRaft.LastAppliedLeCommitIndexProof.
 
-Require Import AllEntriesLeaderLogsTermInterface.
-Require Import AllEntriesLeaderLogsTermProof.
+Require Import VerdiRaft.AllEntriesLeaderLogsTermInterface.
+Require Import VerdiRaft.AllEntriesLeaderLogsTermProof.
 
-Require Import StateMachineCorrectInterface.
-Require Import StateMachineCorrectProof.
+Require Import VerdiRaft.StateMachineCorrectInterface.
+Require Import VerdiRaft.StateMachineCorrectProof.
 
-Require Import OutputGreatestIdInterface.
-Require Import OutputGreatestIdProof.
+Require Import VerdiRaft.OutputGreatestIdInterface.
+Require Import VerdiRaft.OutputGreatestIdProof.
 
-Require Import CurrentTermGtZeroInterface.
-Require Import CurrentTermGtZeroProof.
+Require Import VerdiRaft.CurrentTermGtZeroInterface.
+Require Import VerdiRaft.CurrentTermGtZeroProof.
 
-Require Import TermsAndIndicesFromOneLogInterface.
-Require Import TermsAndIndicesFromOneLogProof.
+Require Import VerdiRaft.TermsAndIndicesFromOneLogInterface.
+Require Import VerdiRaft.TermsAndIndicesFromOneLogProof.
 
-Require Import TermsAndIndicesFromOneInterface.
-Require Import TermsAndIndicesFromOneProof.
+Require Import VerdiRaft.TermsAndIndicesFromOneInterface.
+Require Import VerdiRaft.TermsAndIndicesFromOneProof.
 
-Require Import CandidateTermGtLogInterface.
-Require Import CandidateTermGtLogProof.
+Require Import VerdiRaft.CandidateTermGtLogInterface.
+Require Import VerdiRaft.CandidateTermGtLogProof.
 
-Require Import VotesVotesWithLogCorrespondInterface.
-Require Import VotesVotesWithLogCorrespondProof.
+Require Import VerdiRaft.VotesVotesWithLogCorrespondInterface.
+Require Import VerdiRaft.VotesVotesWithLogCorrespondProof.
 
-Require Import PrevLogLeaderSublogInterface.
-Require Import PrevLogLeaderSublogProof.
+Require Import VerdiRaft.PrevLogLeaderSublogInterface.
+Require Import VerdiRaft.PrevLogLeaderSublogProof.
 
-Require Import AllEntriesIndicesGt0Interface.
-Require Import AllEntriesIndicesGt0Proof.
+Require Import VerdiRaft.AllEntriesIndicesGt0Interface.
+Require Import VerdiRaft.AllEntriesIndicesGt0Proof.
 
-Require Import PrevLogCandidateEntriesTermInterface.
-Require Import PrevLogCandidateEntriesTermProof.
+Require Import VerdiRaft.PrevLogCandidateEntriesTermInterface.
+Require Import VerdiRaft.PrevLogCandidateEntriesTermProof.
 
-Require Import MatchIndexAllEntriesInterface.
-Require Import MatchIndexAllEntriesProof.
+Require Import VerdiRaft.MatchIndexAllEntriesInterface.
+Require Import VerdiRaft.MatchIndexAllEntriesProof.
 
-Require Import MatchIndexLeaderInterface.
-Require Import MatchIndexLeaderProof.
+Require Import VerdiRaft.MatchIndexLeaderInterface.
+Require Import VerdiRaft.MatchIndexLeaderProof.
 
-Require Import MatchIndexSanityInterface.
-Require Import MatchIndexSanityProof.
+Require Import VerdiRaft.MatchIndexSanityInterface.
+Require Import VerdiRaft.MatchIndexSanityProof.
 
-Require Import NoAppendEntriesToLeaderInterface.
-Require Import NoAppendEntriesToLeaderProof.
+Require Import VerdiRaft.NoAppendEntriesToLeaderInterface.
+Require Import VerdiRaft.NoAppendEntriesToLeaderProof.
 
-Require Import NoAppendEntriesToSelfInterface.
-Require Import NoAppendEntriesToSelfProof.
+Require Import VerdiRaft.NoAppendEntriesToSelfInterface.
+Require Import VerdiRaft.NoAppendEntriesToSelfProof.
 
-Require Import NoAppendEntriesRepliesToSelfInterface.
-Require Import NoAppendEntriesRepliesToSelfProof.
+Require Import VerdiRaft.NoAppendEntriesRepliesToSelfInterface.
+Require Import VerdiRaft.NoAppendEntriesRepliesToSelfProof.
 
-Require Import LogAllEntriesInterface.
-Require Import LogAllEntriesProof.
+Require Import VerdiRaft.LogAllEntriesInterface.
+Require Import VerdiRaft.LogAllEntriesProof.
 
-Require Import AppendEntriesReplySublogInterface.
-Require Import AppendEntriesReplySublogProof.
+Require Import VerdiRaft.AppendEntriesReplySublogInterface.
+Require Import VerdiRaft.AppendEntriesReplySublogProof.
 
-Require Import LeaderLogsLogPropertiesInterface.
-Require Import LeaderLogsLogPropertiesProof.
+Require Import VerdiRaft.LeaderLogsLogPropertiesInterface.
+Require Import VerdiRaft.LeaderLogsLogPropertiesProof.
 
-Require Import AppendEntriesRequestReplyCorrespondenceInterface.
-Require Import AppendEntriesRequestReplyCorrespondenceProof.
+Require Import VerdiRaft.AppendEntriesRequestReplyCorrespondenceInterface.
+Require Import VerdiRaft.AppendEntriesRequestReplyCorrespondenceProof.
 
-Require Import AppendEntriesLeaderInterface.
-Require Import AppendEntriesLeaderProof.
+Require Import VerdiRaft.AppendEntriesLeaderInterface.
+Require Import VerdiRaft.AppendEntriesLeaderProof.
 
-Require Import RequestVoteMaxIndexMaxTermInterface.
-Require Import RequestVoteMaxIndexMaxTermProof.
+Require Import VerdiRaft.RequestVoteMaxIndexMaxTermInterface.
+Require Import VerdiRaft.RequestVoteMaxIndexMaxTermProof.
 
-Require Import RequestVoteReplyMoreUpToDateInterface.
-Require Import RequestVoteReplyMoreUpToDateProof.
+Require Import VerdiRaft.RequestVoteReplyMoreUpToDateInterface.
+Require Import VerdiRaft.RequestVoteReplyMoreUpToDateProof.
 
-Require Import RequestVoteReplyTermSanityInterface.
-Require Import RequestVoteReplyTermSanityProof.
+Require Import VerdiRaft.RequestVoteReplyTermSanityInterface.
+Require Import VerdiRaft.RequestVoteReplyTermSanityProof.
 
-Require Import RequestVoteTermSanityInterface.
-Require Import RequestVoteTermSanityProof.
+Require Import VerdiRaft.RequestVoteTermSanityInterface.
+Require Import VerdiRaft.RequestVoteTermSanityProof.
 
-Require Import VotedForMoreUpToDateInterface.
-Require Import VotedForMoreUpToDateProof.
+Require Import VerdiRaft.VotedForMoreUpToDateInterface.
+Require Import VerdiRaft.VotedForMoreUpToDateProof.
 
-Require Import VotedForTermSanityInterface.
-Require Import VotedForTermSanityProof.
+Require Import VerdiRaft.VotedForTermSanityInterface.
+Require Import VerdiRaft.VotedForTermSanityProof.
 
-Require Import VotesReceivedMoreUpToDateInterface.
-Require Import VotesReceivedMoreUpToDateProof.
+Require Import VerdiRaft.VotesReceivedMoreUpToDateInterface.
+Require Import VerdiRaft.VotesReceivedMoreUpToDateProof.
 
-Require Import RaftMsgRefinementInterface.
-Require Import RaftMsgRefinementProof.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
+Require Import VerdiRaft.RaftMsgRefinementProof.
 
-Require Import GhostLogCorrectInterface.
-Require Import GhostLogCorrectProof.
+Require Import VerdiRaft.GhostLogCorrectInterface.
+Require Import VerdiRaft.GhostLogCorrectProof.
 
-Require Import GhostLogsLogPropertiesInterface.
-Require Import GhostLogsLogPropertiesProof.
+Require Import VerdiRaft.GhostLogsLogPropertiesInterface.
+Require Import VerdiRaft.GhostLogsLogPropertiesProof.
 
-Require Import InLogInAllEntriesInterface.
-Require Import InLogInAllEntriesProof.
+Require Import VerdiRaft.InLogInAllEntriesInterface.
+Require Import VerdiRaft.InLogInAllEntriesProof.
 
-Require Import GhostLogAllEntriesInterface.
-Require Import GhostLogAllEntriesProof.
+Require Import VerdiRaft.GhostLogAllEntriesInterface.
+Require Import VerdiRaft.GhostLogAllEntriesProof.
 
-Require Import GhostLogLogMatchingInterface.
-Require Import GhostLogLogMatchingProof.
+Require Import VerdiRaft.GhostLogLogMatchingInterface.
+Require Import VerdiRaft.GhostLogLogMatchingProof.
 
 
 Hint Extern 4 (@BaseParams) => apply base_params : typeclass_instances.

--- a/raft-proofs/EveryEntryWasCreatedHostLogProof.v
+++ b/raft-proofs/EveryEntryWasCreatedHostLogProof.v
@@ -1,9 +1,9 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import LeadersHaveLeaderLogsInterface.
-Require Import EveryEntryWasCreatedInterface.
-Require Import EveryEntryWasCreatedHostLogInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsInterface.
+Require Import VerdiRaft.EveryEntryWasCreatedInterface.
+Require Import VerdiRaft.EveryEntryWasCreatedHostLogInterface.
 
 Section EveryEntryWasCreated.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/EveryEntryWasCreatedProof.v
+++ b/raft-proofs/EveryEntryWasCreatedProof.v
@@ -1,12 +1,12 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import RefinementCommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RefinementCommonDefinitions.
 
-Require Import LeadersHaveLeaderLogsInterface.
-Require Import EveryEntryWasCreatedInterface.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
-Require Import CommonTheorems.
+Require Import VerdiRaft.LeadersHaveLeaderLogsInterface.
+Require Import VerdiRaft.EveryEntryWasCreatedInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 

--- a/raft-proofs/GhostLogAllEntriesProof.v
+++ b/raft-proofs/GhostLogAllEntriesProof.v
@@ -1,15 +1,15 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RefinementSpecLemmas.
-Require Import RaftRefinementInterface.
-Require Import RaftMsgRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RefinementSpecLemmas.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
 
-Require Import InLogInAllEntriesInterface.
+Require Import VerdiRaft.InLogInAllEntriesInterface.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import GhostLogAllEntriesInterface.
+Require Import VerdiRaft.GhostLogAllEntriesInterface.
 
 Section GhostLogAllEntriesProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/GhostLogCorrectProof.v
+++ b/raft-proofs/GhostLogCorrectProof.v
@@ -1,15 +1,15 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import SpecLemmas.
-Require Import RaftMsgRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
 
-Require Import NextIndexSafetyInterface.
-Require Import RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.NextIndexSafetyInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
-Require Import GhostLogCorrectInterface.
+Require Import VerdiRaft.GhostLogCorrectInterface.
 
 Section GhostLogCorrectProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/GhostLogLogMatchingProof.v
+++ b/raft-proofs/GhostLogLogMatchingProof.v
@@ -1,23 +1,23 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import RaftMsgRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
 
-Require Import CommonTheorems.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import RefinedLogMatchingLemmasInterface.
-Require Import GhostLogCorrectInterface.
-Require Import GhostLogsLogPropertiesInterface.
-Require Import TermSanityInterface.
-Require Import AllEntriesLeaderSublogInterface.
-Require Import GhostLogAllEntriesInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.GhostLogCorrectInterface.
+Require Import VerdiRaft.GhostLogsLogPropertiesInterface.
+Require Import VerdiRaft.TermSanityInterface.
+Require Import VerdiRaft.AllEntriesLeaderSublogInterface.
+Require Import VerdiRaft.GhostLogAllEntriesInterface.
 
-Require Import GhostLogLogMatchingInterface.
+Require Import VerdiRaft.GhostLogLogMatchingInterface.
 
 
 Section GhostLogLogMatching.

--- a/raft-proofs/GhostLogsLogPropertiesProof.v
+++ b/raft-proofs/GhostLogsLogPropertiesProof.v
@@ -1,10 +1,10 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftMsgRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import GhostLogsLogPropertiesInterface.
+Require Import VerdiRaft.GhostLogsLogPropertiesInterface.
 
 Section GhostLogsLogProperties.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/InLogInAllEntriesProof.v
+++ b/raft-proofs/InLogInAllEntriesProof.v
@@ -1,13 +1,13 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import CommonTheorems.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import InLogInAllEntriesInterface.
+Require Import VerdiRaft.InLogInAllEntriesInterface.
 
 Section InLogInAllEntries.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/InputBeforeOutputProof.v
+++ b/raft-proofs/InputBeforeOutputProof.v
@@ -1,21 +1,21 @@
 Require Import Verdi.GhostSimulations.
 Require Import Verdi.InverseTraceRelations.
 
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.TraceUtil.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import InputBeforeOutputInterface.
-Require Import AppliedImpliesInputInterface.
-Require Import OutputImpliesAppliedInterface.
-Require Import LastAppliedCommitIndexMatchingInterface.
-Require Import SortedInterface.
-Require Import LogMatchingInterface.
-Require Import StateMachineSafetyInterface.
-Require Import MaxIndexSanityInterface.
-Require Import UniqueIndicesInterface.
+Require Import VerdiRaft.InputBeforeOutputInterface.
+Require Import VerdiRaft.AppliedImpliesInputInterface.
+Require Import VerdiRaft.OutputImpliesAppliedInterface.
+Require Import VerdiRaft.LastAppliedCommitIndexMatchingInterface.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.StateMachineSafetyInterface.
+Require Import VerdiRaft.MaxIndexSanityInterface.
+Require Import VerdiRaft.UniqueIndicesInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
 Section InputBeforeOutput.

--- a/raft-proofs/LastAppliedCommitIndexMatchingProof.v
+++ b/raft-proofs/LastAppliedCommitIndexMatchingProof.v
@@ -1,10 +1,10 @@
-Require Import Raft.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonDefinitions.
 
-Require Import LastAppliedCommitIndexMatchingInterface.
-Require Import LogMatchingInterface.
-Require Import StateMachineSafetyInterface.
-Require Import MaxIndexSanityInterface.
+Require Import VerdiRaft.LastAppliedCommitIndexMatchingInterface.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.StateMachineSafetyInterface.
+Require Import VerdiRaft.MaxIndexSanityInterface.
 
 Section LastAppliedCommitIndexMatching.
 

--- a/raft-proofs/LastAppliedLeCommitIndexProof.v
+++ b/raft-proofs/LastAppliedLeCommitIndexProof.v
@@ -1,8 +1,8 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import LastAppliedLeCommitIndexInterface.
-Require Import SpecLemmas.
-Require Import CommonTheorems.
+Require Import VerdiRaft.LastAppliedLeCommitIndexInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
 

--- a/raft-proofs/LeaderCompletenessProof.v
+++ b/raft-proofs/LeaderCompletenessProof.v
@@ -1,21 +1,21 @@
 Require Import Sumbool.
 
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import RefinementCommonDefinitions.
+Require Import VerdiRaft.RefinementCommonDefinitions.
 
-Require Import LeaderCompletenessInterface.
-Require Import PrefixWithinTermInterface.
-Require Import LeaderLogsTermSanityInterface.
-Require Import LeaderLogsPreservedInterface.
-Require Import EveryEntryWasCreatedInterface.
-Require Import LeaderLogsVotesWithLogInterface.
-Require Import AllEntriesVotesWithLogInterface.
-Require Import VotesWithLogSortedInterface.
-Require Import TermsAndIndicesFromOneInterface.
-Require Import LeaderLogsLogMatchingInterface.
+Require Import VerdiRaft.LeaderCompletenessInterface.
+Require Import VerdiRaft.PrefixWithinTermInterface.
+Require Import VerdiRaft.LeaderLogsTermSanityInterface.
+Require Import VerdiRaft.LeaderLogsPreservedInterface.
+Require Import VerdiRaft.EveryEntryWasCreatedInterface.
+Require Import VerdiRaft.LeaderLogsVotesWithLogInterface.
+Require Import VerdiRaft.AllEntriesVotesWithLogInterface.
+Require Import VerdiRaft.VotesWithLogSortedInterface.
+Require Import VerdiRaft.TermsAndIndicesFromOneInterface.
+Require Import VerdiRaft.LeaderLogsLogMatchingInterface.
 
 Section LeaderCompleteness.
 

--- a/raft-proofs/LeaderLogsCandidateEntriesProof.v
+++ b/raft-proofs/LeaderLogsCandidateEntriesProof.v
@@ -1,20 +1,20 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
-Require Import RefinementCommonTheorems.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.RefinementCommonTheorems.
 
-Require Import CandidateEntriesInterface.
-Require Import CroniesCorrectInterface.
-Require Import CroniesTermInterface.
-Require Import LeaderLogsTermSanityInterface.
+Require Import VerdiRaft.CandidateEntriesInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.CroniesTermInterface.
+Require Import VerdiRaft.LeaderLogsTermSanityInterface.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
-Require Import LeaderLogsCandidateEntriesInterface.
+Require Import VerdiRaft.LeaderLogsCandidateEntriesInterface.
 
 Section CandidateEntriesInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/LeaderLogsContiguousProof.v
+++ b/raft-proofs/LeaderLogsContiguousProof.v
@@ -1,13 +1,13 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import CommonTheorems.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import LeaderLogsContiguousInterface.
-Require Import LogMatchingInterface.
+Require Import VerdiRaft.LeaderLogsContiguousInterface.
+Require Import VerdiRaft.LogMatchingInterface.
 
 Section LeaderLogsContiguous.
 

--- a/raft-proofs/LeaderLogsLogMatchingProof.v
+++ b/raft-proofs/LeaderLogsLogMatchingProof.v
@@ -1,23 +1,23 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import CommonTheorems.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import LogMatchingInterface.
-Require Import LeaderLogsTermSanityInterface.
-Require Import LeaderLogsSortedInterface.
-Require Import SortedInterface.
-Require Import LeaderLogsSublogInterface.
-Require Import LeaderLogsContiguousInterface.
-Require Import TermsAndIndicesFromOneInterface.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.LeaderLogsTermSanityInterface.
+Require Import VerdiRaft.LeaderLogsSortedInterface.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.LeaderLogsSublogInterface.
+Require Import VerdiRaft.LeaderLogsContiguousInterface.
+Require Import VerdiRaft.TermsAndIndicesFromOneInterface.
 
-Require Import LeaderLogsLogMatchingInterface.
+Require Import VerdiRaft.LeaderLogsLogMatchingInterface.
 
 Section LeaderLogsLogMatching.
 

--- a/raft-proofs/LeaderLogsLogPropertiesProof.v
+++ b/raft-proofs/LeaderLogsLogPropertiesProof.v
@@ -1,10 +1,10 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import LeaderLogsLogPropertiesInterface.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.LeaderLogsLogPropertiesInterface.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Section LeaderLogsLogProperties.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/LeaderLogsPreservedProof.v
+++ b/raft-proofs/LeaderLogsPreservedProof.v
@@ -1,17 +1,17 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
-Require Import RefinementCommonTheorems.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.RefinementCommonTheorems.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import LeaderLogsPreservedInterface.
-Require Import LogsLeaderLogsInterface.
-Require Import LeaderLogsTermSanityInterface.
-Require Import LeaderLogsCandidateEntriesInterface.
-Require Import OneLeaderLogPerTermInterface.
-Require Import VotesCorrectInterface.
-Require Import CroniesCorrectInterface.
+Require Import VerdiRaft.LeaderLogsPreservedInterface.
+Require Import VerdiRaft.LogsLeaderLogsInterface.
+Require Import VerdiRaft.LeaderLogsTermSanityInterface.
+Require Import VerdiRaft.LeaderLogsCandidateEntriesInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
 
 Section LeaderLogsPreserved.
 

--- a/raft-proofs/LeaderLogsSortedProof.v
+++ b/raft-proofs/LeaderLogsSortedProof.v
@@ -1,15 +1,15 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import LeaderLogsSortedInterface.
-Require Import SortedInterface.
+Require Import VerdiRaft.LeaderLogsSortedInterface.
+Require Import VerdiRaft.SortedInterface.
 
 
 Section LeaderLogsSorted.

--- a/raft-proofs/LeaderLogsSublogProof.v
+++ b/raft-proofs/LeaderLogsSublogProof.v
@@ -1,24 +1,24 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import CommonTheorems.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import LeaderSublogInterface.
-Require Import LeaderLogsTermSanityInterface.
-Require Import EveryEntryWasCreatedInterface.
-Require Import LeaderLogsCandidateEntriesInterface.
+Require Import VerdiRaft.LeaderSublogInterface.
+Require Import VerdiRaft.LeaderLogsTermSanityInterface.
+Require Import VerdiRaft.EveryEntryWasCreatedInterface.
+Require Import VerdiRaft.LeaderLogsCandidateEntriesInterface.
 
-Require Import CroniesCorrectInterface.
-Require Import VotesCorrectInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
 
-Require Import RefinementCommonTheorems.
+Require Import VerdiRaft.RefinementCommonTheorems.
 
-Require Import LeaderLogsSublogInterface.
+Require Import VerdiRaft.LeaderLogsSublogInterface.
 
 Section LeaderLogsSublog.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/LeaderLogsTermSanityProof.v
+++ b/raft-proofs/LeaderLogsTermSanityProof.v
@@ -1,14 +1,14 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import CandidateTermGtLogInterface.
-Require Import LeaderLogsTermSanityInterface.
+Require Import VerdiRaft.CandidateTermGtLogInterface.
+Require Import VerdiRaft.LeaderLogsTermSanityInterface.
 
 Section LeaderLogsTermSanity.
 

--- a/raft-proofs/LeaderLogsVotesWithLogProof.v
+++ b/raft-proofs/LeaderLogsVotesWithLogProof.v
@@ -1,14 +1,14 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
-Require Import VotesReceivedMoreUpToDateInterface.
-Require Import RequestVoteReplyMoreUpToDateInterface.
+Require Import VerdiRaft.VotesReceivedMoreUpToDateInterface.
+Require Import VerdiRaft.RequestVoteReplyMoreUpToDateInterface.
 
-Require Import LeaderLogsVotesWithLogInterface.
+Require Import VerdiRaft.LeaderLogsVotesWithLogInterface.
 
 Section LeaderLogsVotesWithLog.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/LeaderSublogProof.v
+++ b/raft-proofs/LeaderSublogProof.v
@@ -1,15 +1,15 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import OneLeaderPerTermInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.OneLeaderPerTermInterface.
 
-Require Import CandidateEntriesInterface.
-Require Import RaftRefinementInterface.
-Require Import VotesCorrectInterface.
-Require Import CroniesCorrectInterface.
-Require Import RefinementCommonTheorems.
+Require Import VerdiRaft.CandidateEntriesInterface.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.RefinementCommonTheorems.
 
-Require Import LeaderSublogInterface.
+Require Import VerdiRaft.LeaderSublogInterface.
 
 Hint Extern 4 (@BaseParams) => apply base_params : typeclass_instances.
 Hint Extern 4 (@MultiParams _) => apply multi_params : typeclass_instances.

--- a/raft-proofs/LeadersHaveLeaderLogsProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsProof.v
@@ -1,11 +1,11 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import LeadersHaveLeaderLogsInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsInterface.
 
 Section LeadersHaveLeaderLogs.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
+++ b/raft-proofs/LeadersHaveLeaderLogsStrongProof.v
@@ -1,10 +1,10 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonTheorems.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import LeadersHaveLeaderLogsStrongInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsStrongInterface.
 
 Section LeadersHaveLeaderLogsStrong.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/LogAllEntriesProof.v
+++ b/raft-proofs/LogAllEntriesProof.v
@@ -1,14 +1,14 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import CommonTheorems.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import TermSanityInterface.
-Require Import LogAllEntriesInterface.
+Require Import VerdiRaft.TermSanityInterface.
+Require Import VerdiRaft.LogAllEntriesInterface.
 
 Section LogAllEntries.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/LogMatchingProof.v
+++ b/raft-proofs/LogMatchingProof.v
@@ -1,12 +1,12 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import SpecLemmas.
-Require Import CommonTheorems.
-Require Import SortedInterface.
-Require Import UniqueIndicesInterface.
-Require Import LeaderSublogInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.UniqueIndicesInterface.
+Require Import VerdiRaft.LeaderSublogInterface.
 
-Require Import LogMatchingInterface.
+Require Import VerdiRaft.LogMatchingInterface.
 
 Hint Extern 4 (@BaseParams) => apply base_params : typeclass_instances.
 Hint Extern 4 (@MultiParams _) => apply multi_params : typeclass_instances.

--- a/raft-proofs/LogsLeaderLogsProof.v
+++ b/raft-proofs/LogsLeaderLogsProof.v
@@ -1,23 +1,23 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
 
-Require Import LogsLeaderLogsInterface.
-Require Import LeaderLogsSortedInterface.
-Require Import LeaderLogsContiguousInterface.
-Require Import LeaderLogsLogMatchingInterface.
-Require Import RefinedLogMatchingLemmasInterface.
-Require Import LeadersHaveLeaderLogsStrongInterface.
-Require Import NextIndexSafetyInterface.
-Require Import SortedInterface.
-Require Import LeaderLogsLogPropertiesInterface.
+Require Import VerdiRaft.LogsLeaderLogsInterface.
+Require Import VerdiRaft.LeaderLogsSortedInterface.
+Require Import VerdiRaft.LeaderLogsContiguousInterface.
+Require Import VerdiRaft.LeaderLogsLogMatchingInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsStrongInterface.
+Require Import VerdiRaft.NextIndexSafetyInterface.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.LeaderLogsLogPropertiesInterface.
 
 Section LogsLeaderLogs.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/MatchIndexAllEntriesProof.v
+++ b/raft-proofs/MatchIndexAllEntriesProof.v
@@ -1,30 +1,30 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import CommonTheorems.
-Require Import RefinementCommonTheorems.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.RefinementCommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import NoAppendEntriesToLeaderInterface.
-Require Import NoAppendEntriesToSelfInterface.
-Require Import TermsAndIndicesFromOneLogInterface.
-Require Import RefinedLogMatchingLemmasInterface.
-Require Import LogAllEntriesInterface.
-Require Import AppendEntriesRequestLeaderLogsInterface.
-Require Import LeaderSublogInterface.
-Require Import LeadersHaveLeaderLogsStrongInterface.
-Require Import OneLeaderLogPerTermInterface.
-Require Import MatchIndexLeaderInterface.
-Require Import MatchIndexSanityInterface.
-Require Import AppendEntriesReplySublogInterface.
-Require Import CandidateEntriesInterface.
-Require Import VotesCorrectInterface.
-Require Import CroniesCorrectInterface.
+Require Import VerdiRaft.NoAppendEntriesToLeaderInterface.
+Require Import VerdiRaft.NoAppendEntriesToSelfInterface.
+Require Import VerdiRaft.TermsAndIndicesFromOneLogInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.LogAllEntriesInterface.
+Require Import VerdiRaft.AppendEntriesRequestLeaderLogsInterface.
+Require Import VerdiRaft.LeaderSublogInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsStrongInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.MatchIndexLeaderInterface.
+Require Import VerdiRaft.MatchIndexSanityInterface.
+Require Import VerdiRaft.AppendEntriesReplySublogInterface.
+Require Import VerdiRaft.CandidateEntriesInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
 
-Require Import MatchIndexAllEntriesInterface.
+Require Import VerdiRaft.MatchIndexAllEntriesInterface.
 
 Section MatchIndexAllEntries.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/MatchIndexLeaderProof.v
+++ b/raft-proofs/MatchIndexLeaderProof.v
@@ -1,12 +1,12 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import NoAppendEntriesRepliesToSelfInterface.
+Require Import VerdiRaft.NoAppendEntriesRepliesToSelfInterface.
 
-Require Import MatchIndexLeaderInterface.
+Require Import VerdiRaft.MatchIndexLeaderInterface.
 
 Section MatchIndexLeader.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/MatchIndexSanityProof.v
+++ b/raft-proofs/MatchIndexSanityProof.v
@@ -1,14 +1,14 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import CommonTheorems.
-Require Import SpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import AppendEntriesReplySublogInterface.
+Require Import VerdiRaft.AppendEntriesReplySublogInterface.
 
-Require Import MatchIndexSanityInterface.
-Require Import SortedInterface.
+Require Import VerdiRaft.MatchIndexSanityInterface.
+Require Import VerdiRaft.SortedInterface.
 
 Section MatchIndexSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/NextIndexSafetyProof.v
+++ b/raft-proofs/NextIndexSafetyProof.v
@@ -1,14 +1,14 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import CommonTheorems.
-Require Import SpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import AppendEntriesReplySublogInterface.
-Require Import SortedInterface.
+Require Import VerdiRaft.AppendEntriesReplySublogInterface.
+Require Import VerdiRaft.SortedInterface.
 
-Require Import NextIndexSafetyInterface.
+Require Import VerdiRaft.NextIndexSafetyInterface.
 
 Section NextIndexSafety.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/NoAppendEntriesRepliesToSelfProof.v
+++ b/raft-proofs/NoAppendEntriesRepliesToSelfProof.v
@@ -1,9 +1,9 @@
-Require Import Raft.
-Require Import SpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import NoAppendEntriesRepliesToSelfInterface.
+Require Import VerdiRaft.NoAppendEntriesRepliesToSelfInterface.
 
-Require Import NoAppendEntriesToSelfInterface.
+Require Import VerdiRaft.NoAppendEntriesToSelfInterface.
 
 Section NoAppendEntriesRepliesToSelf.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/NoAppendEntriesToLeaderProof.v
+++ b/raft-proofs/NoAppendEntriesToLeaderProof.v
@@ -1,13 +1,13 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import NoAppendEntriesToSelfInterface.
-Require Import OneLeaderLogPerTermInterface.
-Require Import AppendEntriesRequestsCameFromLeadersInterface.
-Require Import LeadersHaveLeaderLogsInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.NoAppendEntriesToSelfInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.AppendEntriesRequestsCameFromLeadersInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsInterface.
 
-Require Import NoAppendEntriesToLeaderInterface.
+Require Import VerdiRaft.NoAppendEntriesToLeaderInterface.
 
 Section NoAppendEntriesToLeader.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/NoAppendEntriesToSelfProof.v
+++ b/raft-proofs/NoAppendEntriesToSelfProof.v
@@ -1,7 +1,7 @@
-Require Import Raft.
-Require Import SpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import NoAppendEntriesToSelfInterface.
+Require Import VerdiRaft.NoAppendEntriesToSelfInterface.
 
 Section NoAppendEntriesToSelf.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/OneLeaderLogPerTermProof.v
+++ b/raft-proofs/OneLeaderLogPerTermProof.v
@@ -1,20 +1,20 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
-Require Import RefinementCommonTheorems.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
+Require Import VerdiRaft.RefinementCommonTheorems.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import LeaderLogsVotesWithLogInterface.
-Require Import VotesCorrectInterface.
-Require Import CroniesCorrectInterface.
-Require Import VotesVotesWithLogCorrespondInterface.
-Require Import LeaderLogsTermSanityInterface.
-Require Import OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.LeaderLogsVotesWithLogInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.VotesVotesWithLogCorrespondInterface.
+Require Import VerdiRaft.LeaderLogsTermSanityInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
 
 Section OneLeaderLogPerTerm.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/OneLeaderPerTermProof.v
+++ b/raft-proofs/OneLeaderPerTermProof.v
@@ -1,13 +1,13 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import CommonTheorems.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import RaftRefinementInterface.
-Require Import CroniesCorrectInterface.
-Require Import VotesCorrectInterface.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
 
-Require Import OneLeaderPerTermInterface.
+Require Import VerdiRaft.OneLeaderPerTermInterface.
 
 Section OneLeaderPerTermProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/OutputCorrectProof.v
+++ b/raft-proofs/OutputCorrectProof.v
@@ -1,15 +1,15 @@
 Require Import Verdi.TraceRelations.
 
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import OutputCorrectInterface.
-Require Import AppliedEntriesMonotonicInterface.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.OutputCorrectInterface.
+Require Import VerdiRaft.AppliedEntriesMonotonicInterface.
+Require Import VerdiRaft.TraceUtil.
 
-Require Import StateMachineCorrectInterface.
-Require Import SortedInterface.
-Require Import LastAppliedCommitIndexMatchingInterface.
-Require Import LogMatchingInterface.
+Require Import VerdiRaft.StateMachineCorrectInterface.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.LastAppliedCommitIndexMatchingInterface.
+Require Import VerdiRaft.LogMatchingInterface.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 

--- a/raft-proofs/OutputGreatestIdProof.v
+++ b/raft-proofs/OutputGreatestIdProof.v
@@ -1,20 +1,20 @@
 Require Import Verdi.TraceRelations.
 
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import LogMatchingInterface.
-Require Import StateMachineSafetyInterface.
-Require Import AppliedEntriesMonotonicInterface.
-Require Import MaxIndexSanityInterface.
-Require Import StateMachineCorrectInterface.
-Require Import LastAppliedCommitIndexMatchingInterface.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.StateMachineSafetyInterface.
+Require Import VerdiRaft.AppliedEntriesMonotonicInterface.
+Require Import VerdiRaft.MaxIndexSanityInterface.
+Require Import VerdiRaft.StateMachineCorrectInterface.
+Require Import VerdiRaft.LastAppliedCommitIndexMatchingInterface.
+Require Import VerdiRaft.TraceUtil.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SortedInterface.
+Require Import VerdiRaft.SortedInterface.
 
-Require Import OutputGreatestIdInterface.
+Require Import VerdiRaft.OutputGreatestIdInterface.
 
 Section OutputGreatestId.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/OutputImpliesAppliedProof.v
+++ b/raft-proofs/OutputImpliesAppliedProof.v
@@ -1,18 +1,18 @@
 Require Import Verdi.TraceRelations.
 
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import LogMatchingInterface.
-Require Import StateMachineSafetyInterface.
-Require Import AppliedEntriesMonotonicInterface.
-Require Import MaxIndexSanityInterface.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.StateMachineSafetyInterface.
+Require Import VerdiRaft.AppliedEntriesMonotonicInterface.
+Require Import VerdiRaft.MaxIndexSanityInterface.
+Require Import VerdiRaft.TraceUtil.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SortedInterface.
+Require Import VerdiRaft.SortedInterface.
 
-Require Import OutputImpliesAppliedInterface.
+Require Import VerdiRaft.OutputImpliesAppliedInterface.
 
 Section OutputImpliesApplied.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/PrefixWithinTermProof.v
+++ b/raft-proofs/PrefixWithinTermProof.v
@@ -1,25 +1,25 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import RaftRefinementInterface.
-Require Import CommonTheorems.
-Require Import SpecLemmas.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import PrefixWithinTermInterface.
-Require Import LogsLeaderLogsInterface.
-Require Import RefinedLogMatchingLemmasInterface.
-Require Import OneLeaderLogPerTermInterface.
-Require Import LeaderLogsSortedInterface.
-Require Import LeaderLogsSublogInterface.
-Require Import LeaderSublogInterface.
-Require Import NextIndexSafetyInterface.
-Require Import LeaderLogsContiguousInterface.
-Require Import AllEntriesLogMatchingInterface.
-Require Import AppendEntriesRequestTermSanityInterface.
-Require Import AllEntriesLeaderSublogInterface.
+Require Import VerdiRaft.PrefixWithinTermInterface.
+Require Import VerdiRaft.LogsLeaderLogsInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.LeaderLogsSortedInterface.
+Require Import VerdiRaft.LeaderLogsSublogInterface.
+Require Import VerdiRaft.LeaderSublogInterface.
+Require Import VerdiRaft.NextIndexSafetyInterface.
+Require Import VerdiRaft.LeaderLogsContiguousInterface.
+Require Import VerdiRaft.AllEntriesLogMatchingInterface.
+Require Import VerdiRaft.AppendEntriesRequestTermSanityInterface.
+Require Import VerdiRaft.AllEntriesLeaderSublogInterface.
 
 Section PrefixWithinTerm.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/PrevLogCandidateEntriesTermProof.v
+++ b/raft-proofs/PrevLogCandidateEntriesTermProof.v
@@ -1,18 +1,18 @@
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import SpecLemmas.
-Require Import RaftRefinementInterface.
-Require Import CroniesTermInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CroniesTermInterface.
 
-Require Import CroniesCorrectInterface.
-Require Import CandidateEntriesInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.CandidateEntriesInterface.
 
-Require Import RefinementSpecLemmas.
-Require Import RefinementCommonTheorems.
+Require Import VerdiRaft.RefinementSpecLemmas.
+Require Import VerdiRaft.RefinementCommonTheorems.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import PrevLogCandidateEntriesTermInterface.
+Require Import VerdiRaft.PrevLogCandidateEntriesTermInterface.
 
 Section PrevLogCandidateEntriesTerm.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/PrevLogLeaderSublogProof.v
+++ b/raft-proofs/PrevLogLeaderSublogProof.v
@@ -1,16 +1,16 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import SpecLemmas.
-Require Import RaftRefinementInterface.
-Require Import RefinementCommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RefinementCommonDefinitions.
 
-Require Import PrevLogCandidateEntriesTermInterface.
-Require Import VotesCorrectInterface.
-Require Import CroniesCorrectInterface.
-Require Import LeaderSublogInterface.
+Require Import VerdiRaft.PrevLogCandidateEntriesTermInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
+Require Import VerdiRaft.LeaderSublogInterface.
 
-Require Import PrevLogLeaderSublogInterface.
+Require Import VerdiRaft.PrevLogLeaderSublogInterface.
 
 Hint Extern 4 (@BaseParams) => apply base_params : typeclass_instances.
 Hint Extern 4 (@MultiParams _) => apply multi_params : typeclass_instances.

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -1,12 +1,12 @@
 Require Import FunctionalExtensionality.
 
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 Require Import Verdi.DupDropReordering.
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import RaftRefinementInterface.
-Require Import RaftMsgRefinementInterface.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
 
 Section RaftMsgRefinement.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/RaftRefinementProof.v
+++ b/raft-proofs/RaftRefinementProof.v
@@ -1,9 +1,9 @@
 Require Import FunctionalExtensionality.
 
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Set Bullet Behavior "Strict Subproofs".
 

--- a/raft-proofs/RefinedLogMatchingLemmasProof.v
+++ b/raft-proofs/RefinedLogMatchingLemmasProof.v
@@ -1,14 +1,14 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
 
-Require Import LogMatchingInterface.
-Require Import SortedInterface.
-Require Import AllEntriesIndicesGt0Interface.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.AllEntriesIndicesGt0Interface.
 
-Require Import RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
 
 Section RefinedLogMatchingLemmas.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/RequestVoteMaxIndexMaxTermProof.v
+++ b/raft-proofs/RequestVoteMaxIndexMaxTermProof.v
@@ -1,12 +1,12 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
-Require Import RequestVoteMaxIndexMaxTermInterface.
-Require Import RequestVoteTermSanityInterface.
+Require Import VerdiRaft.RequestVoteMaxIndexMaxTermInterface.
+Require Import VerdiRaft.RequestVoteTermSanityInterface.
 
 Section RequestVoteMaxIndexMaxTerm.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/RequestVoteReplyMoreUpToDateProof.v
+++ b/raft-proofs/RequestVoteReplyMoreUpToDateProof.v
@@ -1,16 +1,16 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
-Require Import CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import RequestVoteMaxIndexMaxTermInterface.
-Require Import RequestVoteReplyTermSanityInterface.
-Require Import VotedForMoreUpToDateInterface.
+Require Import VerdiRaft.RequestVoteMaxIndexMaxTermInterface.
+Require Import VerdiRaft.RequestVoteReplyTermSanityInterface.
+Require Import VerdiRaft.VotedForMoreUpToDateInterface.
 
-Require Import RequestVoteReplyMoreUpToDateInterface.
+Require Import VerdiRaft.RequestVoteReplyMoreUpToDateInterface.
 
 Section RequestVoteReplyMoreUpToDate.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/RequestVoteReplyTermSanityProof.v
+++ b/raft-proofs/RequestVoteReplyTermSanityProof.v
@@ -1,11 +1,11 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import RequestVoteTermSanityInterface.
-Require Import RequestVoteReplyTermSanityInterface.
+Require Import VerdiRaft.RequestVoteTermSanityInterface.
+Require Import VerdiRaft.RequestVoteReplyTermSanityInterface.
 
 Section RequestVoteReplyTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/RequestVoteTermSanityProof.v
+++ b/raft-proofs/RequestVoteTermSanityProof.v
@@ -1,10 +1,10 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import RequestVoteTermSanityInterface.
+Require Import VerdiRaft.RequestVoteTermSanityInterface.
 
 Section RequestVoteTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/SortedProof.v
+++ b/raft-proofs/SortedProof.v
@@ -1,10 +1,10 @@
-Require Import Raft.
-Require Import CommonTheorems.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
-Require Import TermSanityInterface.
-Require Import SortedInterface.
+Require Import VerdiRaft.TermSanityInterface.
+Require Import VerdiRaft.SortedInterface.
 
 Section SortedProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/StateMachineCorrectProof.v
+++ b/raft-proofs/StateMachineCorrectProof.v
@@ -1,16 +1,16 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SpecLemmas.
-Require Import CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import SortedInterface.
-Require Import DecompositionWithPostState.
-Require Import MaxIndexSanityInterface.
-Require Import StateMachineSafetyInterface.
-Require Import LogMatchingInterface.
-Require Import StateMachineCorrectInterface.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.DecompositionWithPostState.
+Require Import VerdiRaft.MaxIndexSanityInterface.
+Require Import VerdiRaft.StateMachineSafetyInterface.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.StateMachineCorrectInterface.
 
 Section StateMachineCorrect.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/StateMachineSafetyPrimeProof.v
+++ b/raft-proofs/StateMachineSafetyPrimeProof.v
@@ -1,21 +1,21 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import CommonTheorems.
-Require Import Raft.
-Require Import SortedInterface.
-Require Import RaftRefinementInterface.
-Require Import StateMachineSafetyPrimeInterface.
-Require Import LeaderCompletenessInterface.
-Require Import LeaderLogsContiguousInterface.
-Require Import AllEntriesLeaderLogsInterface.
-Require Import LogMatchingInterface.
-Require Import UniqueIndicesInterface.
-Require Import AppendEntriesRequestLeaderLogsInterface.
-Require Import LeaderLogsSortedInterface.
-Require Import LeaderLogsLogMatchingInterface.
-Require Import LogsLeaderLogsInterface.
-Require Import OneLeaderLogPerTermInterface.
-Require Import RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.StateMachineSafetyPrimeInterface.
+Require Import VerdiRaft.LeaderCompletenessInterface.
+Require Import VerdiRaft.LeaderLogsContiguousInterface.
+Require Import VerdiRaft.AllEntriesLeaderLogsInterface.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.UniqueIndicesInterface.
+Require Import VerdiRaft.AppendEntriesRequestLeaderLogsInterface.
+Require Import VerdiRaft.LeaderLogsSortedInterface.
+Require Import VerdiRaft.LeaderLogsLogMatchingInterface.
+Require Import VerdiRaft.LogsLeaderLogsInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
 
 Local Arguments update {_} {_} {_} _ _ _ _ : simpl never.
 

--- a/raft-proofs/StateMachineSafetyProof.v
+++ b/raft-proofs/StateMachineSafetyProof.v
@@ -1,36 +1,36 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import CommitRecordedCommittedInterface.
-Require Import StateMachineSafetyInterface.
-Require Import StateMachineSafetyPrimeInterface.
-Require Import RaftRefinementInterface.
-Require Import MaxIndexSanityInterface.
-Require Import LeaderCompletenessInterface.
-Require Import SortedInterface.
-Require Import LogMatchingInterface.
-Require Import PrevLogLeaderSublogInterface.
-Require Import CurrentTermGtZeroInterface.
-Require Import LastAppliedLeCommitIndexInterface.
-Require Import MatchIndexAllEntriesInterface.
-Require Import LeadersHaveLeaderLogsInterface.
-Require Import LeaderSublogInterface.
-Require Import TermsAndIndicesFromOneLogInterface.
-Require Import GhostLogCorrectInterface.
-Require Import GhostLogsLogPropertiesInterface.
-Require Import GhostLogLogMatchingInterface.
-Require Import TransitiveCommitInterface.
-Require Import TermSanityInterface.
-Require Import LeadersHaveLeaderLogsStrongInterface.
-Require Import OneLeaderLogPerTermInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.CommitRecordedCommittedInterface.
+Require Import VerdiRaft.StateMachineSafetyInterface.
+Require Import VerdiRaft.StateMachineSafetyPrimeInterface.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.MaxIndexSanityInterface.
+Require Import VerdiRaft.LeaderCompletenessInterface.
+Require Import VerdiRaft.SortedInterface.
+Require Import VerdiRaft.LogMatchingInterface.
+Require Import VerdiRaft.PrevLogLeaderSublogInterface.
+Require Import VerdiRaft.CurrentTermGtZeroInterface.
+Require Import VerdiRaft.LastAppliedLeCommitIndexInterface.
+Require Import VerdiRaft.MatchIndexAllEntriesInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsInterface.
+Require Import VerdiRaft.LeaderSublogInterface.
+Require Import VerdiRaft.TermsAndIndicesFromOneLogInterface.
+Require Import VerdiRaft.GhostLogCorrectInterface.
+Require Import VerdiRaft.GhostLogsLogPropertiesInterface.
+Require Import VerdiRaft.GhostLogLogMatchingInterface.
+Require Import VerdiRaft.TransitiveCommitInterface.
+Require Import VerdiRaft.TermSanityInterface.
+Require Import VerdiRaft.LeadersHaveLeaderLogsStrongInterface.
+Require Import VerdiRaft.OneLeaderLogPerTermInterface.
 
-Require Import RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
-Require Import RaftMsgRefinementInterface.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 

--- a/raft-proofs/TermSanityProof.v
+++ b/raft-proofs/TermSanityProof.v
@@ -1,7 +1,7 @@
-Require Import Raft.
-Require Import CommonTheorems.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import TermSanityInterface.
+Require Import VerdiRaft.TermSanityInterface.
 
 Section TermSanityProof.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/TermsAndIndicesFromOneLogProof.v
+++ b/raft-proofs/TermsAndIndicesFromOneLogProof.v
@@ -1,11 +1,11 @@
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import SpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import TermsAndIndicesFromOneLogInterface.
-Require Import CurrentTermGtZeroInterface.
+Require Import VerdiRaft.TermsAndIndicesFromOneLogInterface.
+Require Import VerdiRaft.CurrentTermGtZeroInterface.
 
 Section TermsAndIndicesFromOneLog.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/TermsAndIndicesFromOneProof.v
+++ b/raft-proofs/TermsAndIndicesFromOneProof.v
@@ -1,13 +1,13 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import TermsAndIndicesFromOneInterface.
-Require Import TermsAndIndicesFromOneLogInterface.
+Require Import VerdiRaft.TermsAndIndicesFromOneInterface.
+Require Import VerdiRaft.TermsAndIndicesFromOneLogInterface.
 
 Section TermsAndIndicesFromOne.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/TransitiveCommitProof.v
+++ b/raft-proofs/TransitiveCommitProof.v
@@ -1,10 +1,10 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import LeaderCompletenessInterface.
-Require Import RefinedLogMatchingLemmasInterface.
+Require Import VerdiRaft.LeaderCompletenessInterface.
+Require Import VerdiRaft.RefinedLogMatchingLemmasInterface.
 
-Require Import TransitiveCommitInterface.
+Require Import VerdiRaft.TransitiveCommitInterface.
 
 Section TransitiveCommit.
 

--- a/raft-proofs/UniqueIndicesProof.v
+++ b/raft-proofs/UniqueIndicesProof.v
@@ -1,10 +1,10 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import SortedInterface.
+Require Import VerdiRaft.SortedInterface.
 
-Require Import CommonTheorems.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import UniqueIndicesInterface.
+Require Import VerdiRaft.UniqueIndicesInterface.
 
 Section UniqueIndices.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/VotedForMoreUpToDateProof.v
+++ b/raft-proofs/VotedForMoreUpToDateProof.v
@@ -1,15 +1,15 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
-Require Import CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import RequestVoteMaxIndexMaxTermInterface.
-Require Import VotedForTermSanityInterface.
+Require Import VerdiRaft.RequestVoteMaxIndexMaxTermInterface.
+Require Import VerdiRaft.VotedForTermSanityInterface.
 
-Require Import VotedForMoreUpToDateInterface.
+Require Import VerdiRaft.VotedForMoreUpToDateInterface.
 
 Section VotedForMoreUpToDate.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/VotedForTermSanityProof.v
+++ b/raft-proofs/VotedForTermSanityProof.v
@@ -1,12 +1,12 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
-Require Import RequestVoteTermSanityInterface.
-Require Import VotedForTermSanityInterface.
+Require Import VerdiRaft.RequestVoteTermSanityInterface.
+Require Import VerdiRaft.VotedForTermSanityInterface.
 
 Section VotedForTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/VotesCorrectProof.v
+++ b/raft-proofs/VotesCorrectProof.v
@@ -1,12 +1,12 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import VotesCorrectInterface.
-Require Import VotesLeCurrentTermInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.VotesLeCurrentTermInterface.
 
 Set Bullet Behavior "Strict Subproofs".
 

--- a/raft-proofs/VotesLeCurrentTermProof.v
+++ b/raft-proofs/VotesLeCurrentTermProof.v
@@ -1,11 +1,11 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import VotesLeCurrentTermInterface.
+Require Import VerdiRaft.VotesLeCurrentTermInterface.
 
 Set Bullet Behavior "Strict Subproofs".
 

--- a/raft-proofs/VotesReceivedMoreUpToDateProof.v
+++ b/raft-proofs/VotesReceivedMoreUpToDateProof.v
@@ -1,14 +1,14 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
-Require Import CommonTheorems.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import RequestVoteReplyMoreUpToDateInterface.
+Require Import VerdiRaft.RequestVoteReplyMoreUpToDateInterface.
 
-Require Import VotesReceivedMoreUpToDateInterface.
+Require Import VerdiRaft.VotesReceivedMoreUpToDateInterface.
 
 Section VotesReceivedMoreUpToDate.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/VotesVotesWithLogCorrespondProof.v
+++ b/raft-proofs/VotesVotesWithLogCorrespondProof.v
@@ -1,9 +1,9 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import VotesVotesWithLogCorrespondInterface.
+Require Import VerdiRaft.VotesVotesWithLogCorrespondInterface.
 
 Section VotesVotesWithLogCorrespond.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/VotesWithLogSortedProof.v
+++ b/raft-proofs/VotesWithLogSortedProof.v
@@ -1,15 +1,15 @@
 Require Import Verdi.GhostSimulations.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import VotesWithLogSortedInterface.
-Require Import SortedInterface.
+Require Import VerdiRaft.VotesWithLogSortedInterface.
+Require Import VerdiRaft.SortedInterface.
 
 Section VotesWithLogSorted.
   Context {orig_base_params : BaseParams}.

--- a/raft-proofs/VotesWithLogTermSanityProof.v
+++ b/raft-proofs/VotesWithLogTermSanityProof.v
@@ -1,11 +1,11 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import SpecLemmas.
-Require Import RefinementSpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.SpecLemmas.
+Require Import VerdiRaft.RefinementSpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Import VotesWithLogTermSanityInterface.
+Require Import VerdiRaft.VotesWithLogTermSanityInterface.
 
 Section VotesWithLogTermSanity.
 

--- a/raft/.gitignore
+++ b/raft/.gitignore
@@ -1,1 +1,0 @@
-RaftState.v

--- a/raft/AllEntriesCandidateEntriesInterface.v
+++ b/raft/AllEntriesCandidateEntriesInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import RefinementCommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RefinementCommonDefinitions.
 
 Section CandidateEntriesInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/AllEntriesIndicesGt0Interface.v
+++ b/raft/AllEntriesIndicesGt0Interface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AllEntriesIndicesGt0.
   Context {orig_base_params : BaseParams}.

--- a/raft/AllEntriesLeaderLogsInterface.v
+++ b/raft/AllEntriesLeaderLogsInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AllEntriesLeaderLogs.
 

--- a/raft/AllEntriesLeaderLogsTermInterface.v
+++ b/raft/AllEntriesLeaderLogsTermInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AllEntriesLeaderLogsTerm.
   Context {orig_base_params : BaseParams}.

--- a/raft/AllEntriesLeaderSublogInterface.v
+++ b/raft/AllEntriesLeaderSublogInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AllEntriesLeaderSublogInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/AllEntriesLogInterface.v
+++ b/raft/AllEntriesLogInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AllEntriesLog.
 

--- a/raft/AllEntriesLogMatchingInterface.v
+++ b/raft/AllEntriesLogMatchingInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AllEntriesLogMatching.
 

--- a/raft/AllEntriesTermSanityInterface.v
+++ b/raft/AllEntriesTermSanityInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AllEntriesTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/AllEntriesVotesWithLogInterface.v
+++ b/raft/AllEntriesVotesWithLogInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AllEntriesVotesWithLog.
 

--- a/raft/AppendEntriesLeaderInterface.v
+++ b/raft/AppendEntriesLeaderInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AppendEntriesLeader.
   Context {orig_base_params : BaseParams}.

--- a/raft/AppendEntriesReplySublogInterface.v
+++ b/raft/AppendEntriesReplySublogInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section AppendEntriesReplySublog.
   Context {orig_base_params : BaseParams}.

--- a/raft/AppendEntriesRequestLeaderLogsInterface.v
+++ b/raft/AppendEntriesRequestLeaderLogsInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AppendEntriesRequestLeaderLogs.
   Context {orig_base_params : BaseParams}.

--- a/raft/AppendEntriesRequestReplyCorrespondenceInterface.v
+++ b/raft/AppendEntriesRequestReplyCorrespondenceInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 
 Section AppendEntriesRequestReplyCorrespondence.

--- a/raft/AppendEntriesRequestTermSanityInterface.v
+++ b/raft/AppendEntriesRequestTermSanityInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AppendEntriesRequestTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/AppendEntriesRequestsCameFromLeadersInterface.v
+++ b/raft/AppendEntriesRequestsCameFromLeadersInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section AppendEntriesRequestsCameFromLeaders.
   Context {orig_base_params : BaseParams}.

--- a/raft/AppliedEntriesMonotonicInterface.v
+++ b/raft/AppliedEntriesMonotonicInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import CommonDefinitions.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section AppliedEntriesMonotonicInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/AppliedImpliesInputInterface.v
+++ b/raft/AppliedImpliesInputInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import CommonDefinitions.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonDefinitions.
+Require Import VerdiRaft.TraceUtil.
 
 Section AppliedImpliesInputInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/CandidateEntriesInterface.v
+++ b/raft/CandidateEntriesInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import RefinementCommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RefinementCommonDefinitions.
 
 Section CandidateEntriesInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/CandidateTermGtLogInterface.v
+++ b/raft/CandidateTermGtLogInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section CandidateTermGtLogInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/CandidatesVoteForSelvesInterface.v
+++ b/raft/CandidatesVoteForSelvesInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section CandidatesVoteForSelvesInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/CausalOrderPreservedInterface.v
+++ b/raft/CausalOrderPreservedInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import CommonDefinitions.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonDefinitions.
+Require Import VerdiRaft.TraceUtil.
 
 Section CausalOrderPreserved.
   Context {orig_base_params : BaseParams}.

--- a/raft/CommitRecordedCommittedInterface.v
+++ b/raft/CommitRecordedCommittedInterface.v
@@ -1,8 +1,8 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import LeaderCompletenessInterface.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.LeaderCompletenessInterface.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section CommitRecordedCommitted.
 

--- a/raft/CommonDefinitions.v
+++ b/raft/CommonDefinitions.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section CommonDefinitions.
   Context {orig_base_params : BaseParams}.

--- a/raft/CommonTheorems.v
+++ b/raft/CommonTheorems.v
@@ -1,11 +1,11 @@
 Require Import PeanoNat.
 
-Require Import RaftState.
-Require Import Raft.
+Require Import VerdiRaft.RaftState.
+Require Import VerdiRaft.Raft.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 
-Require Export CommonDefinitions.
+Require Export VerdiRaft.CommonDefinitions.
 
 Section CommonTheorems.
   Context {orig_base_params : BaseParams}.

--- a/raft/CroniesCorrectInterface.v
+++ b/raft/CroniesCorrectInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section CroniesCorrectInterface.
 

--- a/raft/CroniesTermInterface.v
+++ b/raft/CroniesTermInterface.v
@@ -1,5 +1,5 @@
-Require Import RaftRefinementInterface.
-Require Import Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
 
 Section CroniesTermInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/CurrentTermGtZeroInterface.v
+++ b/raft/CurrentTermGtZeroInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section CurrentTermGtZeroInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/DecompositionWithPostState.v
+++ b/raft/DecompositionWithPostState.v
@@ -1,6 +1,6 @@
 Require Import FunctionalExtensionality.
 
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section DecompositionWithPostState.
 

--- a/raft/EveryEntryWasCreatedHostLogInterface.v
+++ b/raft/EveryEntryWasCreatedHostLogInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import RefinementCommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RefinementCommonDefinitions.
 
 Section EveryEntryWasCreatedHostLogInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/EveryEntryWasCreatedInterface.v
+++ b/raft/EveryEntryWasCreatedInterface.v
@@ -1,7 +1,7 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
-Require Import RefinementCommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
+Require Import VerdiRaft.RefinementCommonDefinitions.
 
 Section EveryEntryWasCreated.
   Context {orig_base_params : BaseParams}.

--- a/raft/GhostLogAllEntriesInterface.v
+++ b/raft/GhostLogAllEntriesInterface.v
@@ -1,7 +1,7 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import RaftRefinementInterface.
-Require Import RaftMsgRefinementInterface.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
 
 Section GhostLogAllEntriesInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/GhostLogCorrectInterface.v
+++ b/raft/GhostLogCorrectInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import RaftMsgRefinementInterface.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
 
 Section GhostLogCorrectInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/GhostLogLogMatchingInterface.v
+++ b/raft/GhostLogLogMatchingInterface.v
@@ -1,7 +1,7 @@
-Require Import Raft.
-Require Import RaftMsgRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
 
-Require Import CommonDefinitions.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section GhostLogLogMatching.
 

--- a/raft/GhostLogsLogPropertiesInterface.v
+++ b/raft/GhostLogsLogPropertiesInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftMsgRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftMsgRefinementInterface.
 
 Section GhostLogsLogProperties.
   Context {orig_base_params : BaseParams}.

--- a/raft/InLogInAllEntriesInterface.v
+++ b/raft/InLogInAllEntriesInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section InLogInAllEntries.
 

--- a/raft/InputBeforeOutputInterface.v
+++ b/raft/InputBeforeOutputInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.TraceUtil.
 
 Section InputBeforeOutputInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/LastAppliedCommitIndexMatchingInterface.v
+++ b/raft/LastAppliedCommitIndexMatchingInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section LastAppliedCommitIndexMatching.
 

--- a/raft/LastAppliedLeCommitIndexInterface.v
+++ b/raft/LastAppliedLeCommitIndexInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section LastAppliedLeCommitIndexInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderCompletenessInterface.v
+++ b/raft/LeaderCompletenessInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section LeaderCompleteness.
 

--- a/raft/LeaderLogsCandidateEntriesInterface.v
+++ b/raft/LeaderLogsCandidateEntriesInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import RefinementCommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RefinementCommonDefinitions.
 
 Section CandidateEntriesInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderLogsContiguousInterface.v
+++ b/raft/LeaderLogsContiguousInterface.v
@@ -1,7 +1,7 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import CommonTheorems.
+Require Import VerdiRaft.CommonTheorems.
 
 Section LeaderLogsContiguous.
 

--- a/raft/LeaderLogsLogMatchingInterface.v
+++ b/raft/LeaderLogsLogMatchingInterface.v
@@ -1,7 +1,7 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import CommonDefinitions.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section LeaderLogsLogMatching.
 

--- a/raft/LeaderLogsLogPropertiesInterface.v
+++ b/raft/LeaderLogsLogPropertiesInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section LeaderLogsLogProperties.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderLogsPreservedInterface.v
+++ b/raft/LeaderLogsPreservedInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section LeaderLogsPreserved.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderLogsSortedInterface.v
+++ b/raft/LeaderLogsSortedInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section LeaderLogsSorted.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderLogsSublogInterface.v
+++ b/raft/LeaderLogsSublogInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section LeaderLogsSublogInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderLogsTermSanityInterface.v
+++ b/raft/LeaderLogsTermSanityInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section LeaderLogsTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderLogsVotesWithLogInterface.v
+++ b/raft/LeaderLogsVotesWithLogInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section LeaderLogsVotesWithLog.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeaderSublogInterface.v
+++ b/raft/LeaderSublogInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section LeaderSublogInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeadersHaveLeaderLogsInterface.v
+++ b/raft/LeadersHaveLeaderLogsInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section LeadersHaveLeaderLogs.
   Context {orig_base_params : BaseParams}.

--- a/raft/LeadersHaveLeaderLogsStrongInterface.v
+++ b/raft/LeadersHaveLeaderLogsStrongInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section LeadersHaveLeaderLogsStrong.
   Context {orig_base_params : BaseParams}.

--- a/raft/LogAllEntriesInterface.v
+++ b/raft/LogAllEntriesInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section LogAllEntries.
 

--- a/raft/LogMatchingInterface.v
+++ b/raft/LogMatchingInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import CommonDefinitions.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section LogMatchingInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/LogsLeaderLogsInterface.v
+++ b/raft/LogsLeaderLogsInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section LogsLeaderLogs.
   Context {orig_base_params : BaseParams}.

--- a/raft/MatchIndexAllEntriesInterface.v
+++ b/raft/MatchIndexAllEntriesInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section MatchIndexAllEntries.
 

--- a/raft/MatchIndexLeaderInterface.v
+++ b/raft/MatchIndexLeaderInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section MatchIndexLeader.
   Context {orig_base_params : BaseParams}.

--- a/raft/MatchIndexSanityInterface.v
+++ b/raft/MatchIndexSanityInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section MatchIndexSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/MaxIndexSanityInterface.v
+++ b/raft/MaxIndexSanityInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section MaxIndexSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/NextIndexSafetyInterface.v
+++ b/raft/NextIndexSafetyInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section NextIndexSafety.
   Context {orig_base_params : BaseParams}.

--- a/raft/NoAppendEntriesRepliesToSelfInterface.v
+++ b/raft/NoAppendEntriesRepliesToSelfInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section NoAppendEntriesRepliesToSelfInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/NoAppendEntriesToLeaderInterface.v
+++ b/raft/NoAppendEntriesToLeaderInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section NoAppendEntriesToLeaderInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/NoAppendEntriesToSelfInterface.v
+++ b/raft/NoAppendEntriesToSelfInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section NoAppendEntriesToSelfInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/OneLeaderLogPerTermInterface.v
+++ b/raft/OneLeaderLogPerTermInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section OneLeaderLogPerTerm.
 

--- a/raft/OneLeaderPerTermInterface.v
+++ b/raft/OneLeaderPerTermInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section OneLeaderPerTermInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/OutputCorrectInterface.v
+++ b/raft/OutputCorrectInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import CommonDefinitions.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonDefinitions.
+Require Import VerdiRaft.TraceUtil.
 
 Section OutputCorrect.
   Context {orig_base_params : BaseParams}.

--- a/raft/OutputGreatestIdInterface.v
+++ b/raft/OutputGreatestIdInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import CommonDefinitions.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonDefinitions.
+Require Import VerdiRaft.TraceUtil.
 
 Section OutputGreatestId.
   Context {orig_base_params : BaseParams}.

--- a/raft/OutputImpliesAppliedInterface.v
+++ b/raft/OutputImpliesAppliedInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import CommonDefinitions.
-Require Import TraceUtil.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonDefinitions.
+Require Import VerdiRaft.TraceUtil.
 
 Section OutputImpliesApplied.
   Context {orig_base_params : BaseParams}.

--- a/raft/PrefixWithinTermInterface.v
+++ b/raft/PrefixWithinTermInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section PrefixWithinTerm.
   Context {orig_base_params : BaseParams}.

--- a/raft/PrevLogCandidateEntriesTermInterface.v
+++ b/raft/PrevLogCandidateEntriesTermInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import RefinementCommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.RefinementCommonDefinitions.
 
 Section PrevLogCandidateEntriesTermInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/PrevLogLeaderSublogInterface.v
+++ b/raft/PrevLogLeaderSublogInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section PrevLogLeaderSublogInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/Raft.v
+++ b/raft/Raft.v
@@ -1,5 +1,5 @@
 Require Export Verdi.Verdi.
-Require Import RaftState.
+Require Import VerdiRaft.RaftState.
 Require Export StructTact.Fin.
 
 Open Scope bool.

--- a/raft/RaftLinearizableProofs.v
+++ b/raft/RaftLinearizableProofs.v
@@ -1,15 +1,15 @@
 Require Import Sumbool.
 
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import TraceUtil.
-Require Import Linearizability.
-Require Import OutputImpliesAppliedInterface.
-Require Import AppliedImpliesInputInterface.
-Require Import CausalOrderPreservedInterface.
-Require Import OutputCorrectInterface.
-Require Import InputBeforeOutputInterface.
-Require Import OutputGreatestIdInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.TraceUtil.
+Require Import VerdiRaft.Linearizability.
+Require Import VerdiRaft.OutputImpliesAppliedInterface.
+Require Import VerdiRaft.AppliedImpliesInputInterface.
+Require Import VerdiRaft.CausalOrderPreservedInterface.
+Require Import VerdiRaft.OutputCorrectInterface.
+Require Import VerdiRaft.InputBeforeOutputInterface.
+Require Import VerdiRaft.OutputGreatestIdInterface.
 
 Section RaftLinearizableProofs.
   Context {orig_base_params : BaseParams}.

--- a/raft/RaftMsgRefinementInterface.v
+++ b/raft/RaftMsgRefinementInterface.v
@@ -1,7 +1,7 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section RaftMsgRefinementInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/RaftRefinementInterface.v
+++ b/raft/RaftRefinementInterface.v
@@ -1,5 +1,5 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section RaftRefinementInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/RaftState.v
+++ b/raft/RaftState.v
@@ -1,0 +1,127 @@
+(* Remember to re-run
+     python2 script/extract_record_notation.py raft/RaftState.v.rec raft_data > raft/RaftState.v
+   after editing this file!
+   Running `make raft/RaftState.v` should take care of this for you. *)
+Section RaftState.
+  Variable term : Type.
+  Variable name : Type.
+  Variable entry : Type.
+  Variable logIndex : Type.
+  Variable serverType : Type.
+  Variable stateMachineData : Type.
+  Variable output : Type.
+
+  Record raft_data :=
+    mkRaft_data {
+        (* persistent *)
+        currentTerm : term;
+        votedFor : option name;
+        leaderId : option name;
+        log : list entry;
+        (* volatile *)
+        commitIndex : logIndex;
+        lastApplied : logIndex;
+        stateMachine : stateMachineData;
+        (* leader state *)
+        nextIndex : list (name * logIndex);
+        matchIndex : list (name * logIndex);
+        shouldSend : bool;
+        (* candidate state *)
+        votesReceived : list name;
+        (* whoami *)
+        type : serverType;
+        (* client request state *)
+        clientCache : list (nat * (nat * output));
+        (* ghost variables *)
+        electoralVictories : list (term * list name * list entry)
+      }.
+
+
+Definition set_raft_data_currentTerm a v := mkRaft_data v (votedFor a) (leaderId a) (log a) (commitIndex a) (lastApplied a) (stateMachine a) (nextIndex a) (matchIndex a) (shouldSend a) (votesReceived a) (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_votedFor a v := mkRaft_data (currentTerm a) v (leaderId a) (log a) (commitIndex a) (lastApplied a) (stateMachine a) (nextIndex a) (matchIndex a) (shouldSend a) (votesReceived a) (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_leaderId a v := mkRaft_data (currentTerm a) (votedFor a) v (log a) (commitIndex a) (lastApplied a) (stateMachine a) (nextIndex a) (matchIndex a) (shouldSend a) (votesReceived a) (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_log a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) v (commitIndex a) (lastApplied a) (stateMachine a) (nextIndex a) (matchIndex a) (shouldSend a) (votesReceived a) (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_commitIndex a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) (log a) v (lastApplied a) (stateMachine a) (nextIndex a) (matchIndex a) (shouldSend a) (votesReceived a) (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_lastApplied a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) (log a) (commitIndex a) v (stateMachine a) (nextIndex a) (matchIndex a) (shouldSend a) (votesReceived a) (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_stateMachine a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) (log a) (commitIndex a) (lastApplied a) v (nextIndex a) (matchIndex a) (shouldSend a) (votesReceived a) (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_nextIndex a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) (log a) (commitIndex a) (lastApplied a) (stateMachine a) v (matchIndex a) (shouldSend a) (votesReceived a) (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_matchIndex a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) (log a) (commitIndex a) (lastApplied a) (stateMachine a) (nextIndex a) v (shouldSend a) (votesReceived a) (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_shouldSend a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) (log a) (commitIndex a) (lastApplied a) (stateMachine a) (nextIndex a) (matchIndex a) v (votesReceived a) (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_votesReceived a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) (log a) (commitIndex a) (lastApplied a) (stateMachine a) (nextIndex a) (matchIndex a) (shouldSend a) v (type a) (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_type a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) (log a) (commitIndex a) (lastApplied a) (stateMachine a) (nextIndex a) (matchIndex a) (shouldSend a) (votesReceived a) v (clientCache a) (electoralVictories a).
+
+Definition set_raft_data_clientCache a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) (log a) (commitIndex a) (lastApplied a) (stateMachine a) (nextIndex a) (matchIndex a) (shouldSend a) (votesReceived a) (type a) v (electoralVictories a).
+
+Definition set_raft_data_electoralVictories a v := mkRaft_data (currentTerm a) (votedFor a) (leaderId a) (log a) (commitIndex a) (lastApplied a) (stateMachine a) (nextIndex a) (matchIndex a) (shouldSend a) (votesReceived a) (type a) (clientCache a) v.
+
+End RaftState.
+
+
+
+Notation "{[ a 'with' 'currentTerm' := v ]}" := (set_raft_data_currentTerm  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'votedFor' := v ]}" := (set_raft_data_votedFor  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'leaderId' := v ]}" := (set_raft_data_leaderId  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'log' := v ]}" := (set_raft_data_log  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'commitIndex' := v ]}" := (set_raft_data_commitIndex  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'lastApplied' := v ]}" := (set_raft_data_lastApplied  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'stateMachine' := v ]}" := (set_raft_data_stateMachine  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'nextIndex' := v ]}" := (set_raft_data_nextIndex  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'matchIndex' := v ]}" := (set_raft_data_matchIndex  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'shouldSend' := v ]}" := (set_raft_data_shouldSend  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'votesReceived' := v ]}" := (set_raft_data_votesReceived  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'type' := v ]}" := (set_raft_data_type  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'clientCache' := v ]}" := (set_raft_data_clientCache  _ _ _ _ _ _ _ a v).
+
+Notation "{[ a 'with' 'electoralVictories' := v ]}" := (set_raft_data_electoralVictories  _ _ _ _ _ _ _ a v).
+
+
+Arguments set_raft_data_currentTerm  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_votedFor  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_leaderId  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_log  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_commitIndex  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_lastApplied  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_stateMachine  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_nextIndex  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_matchIndex  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_shouldSend  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_votesReceived  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_type  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_clientCache  _ _ _ _ _ _ _ _ _/.
+
+Arguments set_raft_data_electoralVictories  _ _ _ _ _ _ _ _ _/.

--- a/raft/RaftState.v.rec
+++ b/raft/RaftState.v.rec
@@ -1,3 +1,7 @@
+(* Remember to re-run
+     python2 script/extract_record_notation.py raft/RaftState.v.rec raft_data > raft/RaftState.v
+   after editing this file!
+   Running `make raft/RaftState.v` should take care of this for you. *)
 Section RaftState.
   Variable term : Type.
   Variable name : Type.

--- a/raft/RefinedLogMatchingLemmasInterface.v
+++ b/raft/RefinedLogMatchingLemmasInterface.v
@@ -1,7 +1,7 @@
-Require Import CommonTheorems.
+Require Import VerdiRaft.CommonTheorems.
 
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section RefinedLogMatchingLemmas.
   Context {orig_base_params : BaseParams}.

--- a/raft/RefinementCommonDefinitions.v
+++ b/raft/RefinementCommonDefinitions.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section CommonDefinitions.
   Context {orig_base_params : BaseParams}.

--- a/raft/RefinementCommonTheorems.v
+++ b/raft/RefinementCommonTheorems.v
@@ -1,14 +1,14 @@
 Require Import Verdi.GhostSimulations.
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
-Require Import VotesCorrectInterface.
-Require Import CroniesCorrectInterface.
+Require Import VerdiRaft.VotesCorrectInterface.
+Require Import VerdiRaft.CroniesCorrectInterface.
 
-Require Import CommonTheorems.
-Require Export RefinementCommonDefinitions.
+Require Import VerdiRaft.CommonTheorems.
+Require Export VerdiRaft.RefinementCommonDefinitions.
 
-Require Import SpecLemmas.
+Require Import VerdiRaft.SpecLemmas.
 
 Local Arguments update {_} {_} _ _ _ _ _ : simpl never.
 

--- a/raft/RefinementSpecLemmas.v
+++ b/raft/RefinementSpecLemmas.v
@@ -1,7 +1,7 @@
-Require Import Raft.
-Require Import CommonTheorems.
-Require Import RaftRefinementInterface.
-Require Import SpecLemmas.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.SpecLemmas.
 
 Section SpecLemmas.
 

--- a/raft/RequestVoteMaxIndexMaxTermInterface.v
+++ b/raft/RequestVoteMaxIndexMaxTermInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section RequestVoteMaxIndexMaxTerm.
   Context {orig_base_params : BaseParams}.

--- a/raft/RequestVoteReplyMoreUpToDateInterface.v
+++ b/raft/RequestVoteReplyMoreUpToDateInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section RequestVoteReplyMoreUpToDate.
   Context {orig_base_params : BaseParams}.

--- a/raft/RequestVoteReplyTermSanityInterface.v
+++ b/raft/RequestVoteReplyTermSanityInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section RequestVoteReplyTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/RequestVoteTermSanityInterface.v
+++ b/raft/RequestVoteTermSanityInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section RequestVoteTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/SortedInterface.v
+++ b/raft/SortedInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import CommonDefinitions.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section SortedInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/SpecLemmas.v
+++ b/raft/SpecLemmas.v
@@ -1,6 +1,6 @@
-Require Import RaftState.
-Require Import Raft.
-Require Import CommonTheorems.
+Require Import VerdiRaft.RaftState.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonTheorems.
 
 Section SpecLemmas.
 

--- a/raft/StateMachineCorrectInterface.v
+++ b/raft/StateMachineCorrectInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section StateMachineCorrect.
   Context {orig_base_params : BaseParams}.

--- a/raft/StateMachineSafetyInterface.v
+++ b/raft/StateMachineSafetyInterface.v
@@ -1,6 +1,6 @@
-Require Import CommonDefinitions.
+Require Import VerdiRaft.CommonDefinitions.
 
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section StateMachineSafety.
   Context {orig_base_params : BaseParams}.

--- a/raft/StateMachineSafetyPrimeInterface.v
+++ b/raft/StateMachineSafetyPrimeInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import LeaderCompletenessInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.LeaderCompletenessInterface.
 
 Section StateMachineSafety'.
   Context {orig_base_params : BaseParams}.

--- a/raft/TermSanityInterface.v
+++ b/raft/TermSanityInterface.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section TermSanityInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/TermsAndIndicesFromOneInterface.v
+++ b/raft/TermsAndIndicesFromOneInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section TermsAndIndicesFromOne.
   Context {orig_base_params : BaseParams}.

--- a/raft/TermsAndIndicesFromOneLogInterface.v
+++ b/raft/TermsAndIndicesFromOneLogInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import CommonDefinitions.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section TermsAndIndicesFromOneLogInterface.
   Context {orig_base_params : BaseParams}.

--- a/raft/TraceUtil.v
+++ b/raft/TraceUtil.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
 Section TraceUtil.
   Context {orig_base_params : BaseParams}.

--- a/raft/TransitiveCommitInterface.v
+++ b/raft/TransitiveCommitInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import LeaderCompletenessInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.LeaderCompletenessInterface.
 
 Section TransitiveCommit.
 

--- a/raft/UniqueIndicesInterface.v
+++ b/raft/UniqueIndicesInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 
-Require Import CommonDefinitions.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section UniqueIndicesInterface.
 

--- a/raft/VotedForMoreUpToDateInterface.v
+++ b/raft/VotedForMoreUpToDateInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section VotedForMoreUpToDate.
   Context {orig_base_params : BaseParams}.

--- a/raft/VotedForTermSanityInterface.v
+++ b/raft/VotedForTermSanityInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section VotedForTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/raft/VotesCorrectInterface.v
+++ b/raft/VotesCorrectInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section VotesCorrectInterface.
 

--- a/raft/VotesLeCurrentTermInterface.v
+++ b/raft/VotesLeCurrentTermInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section VotesLeCurrentTermInterface.
 

--- a/raft/VotesReceivedMoreUpToDateInterface.v
+++ b/raft/VotesReceivedMoreUpToDateInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section VotesReceivedMoreUpToDate.
   Context {orig_base_params : BaseParams}.

--- a/raft/VotesVotesWithLogCorrespondInterface.v
+++ b/raft/VotesVotesWithLogCorrespondInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section VotesVotesWithLogCorrespond.
   Context {orig_base_params : BaseParams}.

--- a/raft/VotesWithLogSortedInterface.v
+++ b/raft/VotesWithLogSortedInterface.v
@@ -1,6 +1,6 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
-Require Import CommonDefinitions.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
+Require Import VerdiRaft.CommonDefinitions.
 
 Section VotesWithLogSorted.
   Context {orig_base_params : BaseParams}.

--- a/raft/VotesWithLogTermSanityInterface.v
+++ b/raft/VotesWithLogTermSanityInterface.v
@@ -1,5 +1,5 @@
-Require Import Raft.
-Require Import RaftRefinementInterface.
+Require Import VerdiRaft.Raft.
+Require Import VerdiRaft.RaftRefinementInterface.
 
 Section VotesWithLogTermSanity.
   Context {orig_base_params : BaseParams}.

--- a/script/assumptions.v
+++ b/script/assumptions.v
@@ -1,4 +1,4 @@
-Require Import EndToEndLinearizability.
+Require Import VerdiRaft.EndToEndLinearizability.
 
 About raft_linearizable.
 Print Assumptions raft_linearizable.

--- a/systems/VarDRaft.v
+++ b/systems/VarDRaft.v
@@ -1,4 +1,4 @@
-Require Import Raft.
+Require Import VerdiRaft.Raft.
 Require Import Verdi.VarD.
 
 Section VarDRaft.


### PR DESCRIPTION
As packaged, this builds and installs all the verdi-raft proofs, but `vard` no longer builds by default.

I have built it successfully using Coq OPAM versions `8.6`, `8.6.dev`, and `dev`.

Everything is namespaced under `VerdiRaft`.

The autogenerated `RaftState.v` file is now tracked so that we don't need to depend on python for builds.

Do not merge until uwplse/verdi#113 is merged.