### PR TITLE
Fix some extraction warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,9 @@ env:
     - COQ_VERSION=8.6
     - SSREFLECT_VERSION=1.6.1
   matrix:
-    - MODE=build
-      TARGET=default
-    - MODE=build
-      TARGET=quick
-    - MODE=vard-test
-      TARGET=default
+    - MODE=build TARGET=default
+    - MODE=build TARGET=quick
+    - MODE=vard-test TARGET=default
 script: bash -ex .travis-ci.sh
 sudo: false
 notifications:

--- a/opam
+++ b/opam
@@ -12,7 +12,7 @@ build: [
   [ "./configure" ]
   [ make "-j%{jobs}%" ]
 ]
-install: [ make install ]
+install: [ make "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/VerdiRaft'" ]
 depends: [
   "coq" {((>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~"))}

--- a/raft/Raft.v
+++ b/raft/Raft.v
@@ -64,18 +64,18 @@ Section Raft.
   Proof. decide equality. Defined.
 
   Definition term_eq_dec : forall x y : term, {x = y} + {x <> y}.
-  Proof using.  apply eq_nat_dec. Qed.
+  Proof.  apply eq_nat_dec. Defined.
 
   Definition entry_eq_dec : forall x y : entry, {x = y} + {x <> y}.
-  Proof using.  decide equality; eauto using input_eq_dec, name_eq_dec, term_eq_dec. Qed.
+  Proof.  decide equality; eauto using input_eq_dec, name_eq_dec, term_eq_dec. Defined.
 
 
   Definition msg_eq_dec : forall x y: msg, {x = y} + {x <> y}.
-  Proof using. 
+  Proof.
     decide equality;
       eauto using name_eq_dec, input_eq_dec, term_eq_dec, Bool.bool_dec,
                   list_eq_dec, entry_eq_dec.
-  Qed.
+  Defined.
 
   Definition raft_data :=
     RaftState.raft_data term name entry logIndex serverType data output.


### PR DESCRIPTION
Extraction ignores opacity, but shows warnings in Coq 8.6. This PR makes some extracted functions in `Raft.v` transparent to prevent the warnings. To me, it also usually makes philosophical sense for non-Prop functions to be transparent.