### PR TITLE
adapt to upstream changes to ghost simulation type classes

### DIFF
--- a/raft-proofs/GhostLogLogMatchingProof.v
+++ b/raft-proofs/GhostLogLogMatchingProof.v
@@ -98,7 +98,7 @@ Section GhostLogLogMatching.
       repeat break_match; simpl in *; auto.
     match goal with
       | H : context [contiguous_range_exact_lo] |- _ =>
-        specialize (H (@mgv_deghost_packet _ _ _ ghost_log_params p));
+        specialize (H (@mgv_deghost_packet _ _ ghost_log_params p));
           eapply H; simpl in *; eauto
     end.
     apply in_map_iff. eexists; eauto.

--- a/raft-proofs/RaftMsgRefinementProof.v
+++ b/raft-proofs/RaftMsgRefinementProof.v
@@ -27,7 +27,7 @@ Section RaftMsgRefinement.
       nwPackets net = xs ++ p :: ys ->
       (forall h, st' h = update name_eq_dec (nwState net) (pDst p) (gd, d) h) ->
       (forall p', In p' ps' -> In p' (xs ++ ys) \/
-                             In p' (send_packets (pDst p) (@add_ghost_msg _ _ _ ghost_log_params (pDst p) (gd, d) l))) ->
+                             In p' (send_packets (pDst p) (@add_ghost_msg _ _ ghost_log_params (pDst p) (gd, d) l))) ->
       P (mkNetwork ps' st').
   Proof using. 
     intros.
@@ -50,7 +50,7 @@ Section RaftMsgRefinement.
       msg_refined_raft_intermediate_reachable net ->
       (forall h', st' h' = update name_eq_dec (nwState net) h (gd, d) h') ->
       (forall p', In p' ps' -> In p' (nwPackets net) \/
-                         In p' (send_packets h (@add_ghost_msg _ _ _ ghost_log_params h (gd, d) l))) ->
+                         In p' (send_packets h (@add_ghost_msg _ _ ghost_log_params h (gd, d) l))) ->
       P (mkNetwork ps' st').
   Proof using. 
     intros.
@@ -92,7 +92,7 @@ Section RaftMsgRefinement.
            (msg_refined_raft_intermediate_reachable
               {|
                 nwPackets := (xs ++ ys) ++ send_packets (pDst p)
-                                       (@add_ghost_msg _ _ _ ghost_log_params (pDst p)
+                                       (@add_ghost_msg _ _ ghost_log_params (pDst p)
                                                        (post_ghost_state, r0) l4);
                 nwState := update name_eq_dec (nwState net) (pDst p)
                                   (post_ghost_state, r0) |})
@@ -102,11 +102,11 @@ Section RaftMsgRefinement.
               {|
                 nwPackets := (xs ++ ys) ++
                                        send_packets (pDst p)
-                                       (@add_ghost_msg _ _ _ ghost_log_params (pDst p)
+                                       (@add_ghost_msg _ _ ghost_log_params (pDst p)
                                                        (post_ghost_state, r0) l4)
                                        ++
                                        send_packets (pDst p)
-                                       (@add_ghost_msg _ _ _ ghost_log_params (pDst p)
+                                       (@add_ghost_msg _ _ ghost_log_params (pDst p)
                                                        (post_ghost_state, r1) l5);
                 nwState := update name_eq_dec (nwState net) (pDst p)
                                   (post_ghost_state, r1) |}) by
@@ -180,7 +180,7 @@ Section RaftMsgRefinement.
            (msg_refined_raft_intermediate_reachable
               {|
                 nwPackets := (nwPackets net) ++ send_packets h
-                                       (@add_ghost_msg _ _ _ ghost_log_params h
+                                       (@add_ghost_msg _ _ ghost_log_params h
                                                        (post_ghost_state, r0) l4);
                 nwState := update name_eq_dec (nwState net) h
                                   (post_ghost_state, r0) |})
@@ -190,11 +190,11 @@ Section RaftMsgRefinement.
               {|
                 nwPackets := (nwPackets net) ++
                                        send_packets h
-                                       (@add_ghost_msg _ _ _ ghost_log_params h
+                                       (@add_ghost_msg _ _ ghost_log_params h
                                                        (post_ghost_state, r0) l4)
                                        ++
                                        send_packets h
-                                       (@add_ghost_msg _ _ _ ghost_log_params h
+                                       (@add_ghost_msg _ _ ghost_log_params h
                                                        (post_ghost_state, r1) l6);
                 nwState := update name_eq_dec (nwState net) h
                                   (post_ghost_state, r1) |}) by
@@ -293,7 +293,7 @@ Section RaftMsgRefinement.
       nwPackets net = xs ++ p :: ys ->
       (forall h, st' h = update name_eq_dec (nwState net) (pDst p) (gd, d) h) ->
       (forall p', In p' ps' -> In p' (xs ++ ys) \/
-                             In p' (send_packets (pDst p) (@add_ghost_msg _ _ _ ghost_log_params (pDst p) (gd, d) l))) ->
+                             In p' (send_packets (pDst p) (@add_ghost_msg _ _ ghost_log_params (pDst p) (gd, d) l))) ->
       P (mkNetwork ps' st').
   Proof using. 
     intros.
@@ -317,7 +317,7 @@ Section RaftMsgRefinement.
       msg_refined_raft_intermediate_reachable (mkNetwork ps' st') ->
       (forall h', st' h' = update name_eq_dec (nwState net) h (gd, d) h') ->
       (forall p', In p' ps' -> In p' (nwPackets net) \/
-                         In p' (send_packets h (@add_ghost_msg _ _ _ ghost_log_params h (gd, d) l))) ->
+                         In p' (send_packets h (@add_ghost_msg _ _ ghost_log_params h (gd, d) l))) ->
       P (mkNetwork ps' st').
   Proof using. 
     intros.
@@ -370,7 +370,7 @@ Section RaftMsgRefinement.
            (msg_refined_raft_intermediate_reachable
               {|
                 nwPackets := (xs ++ ys) ++ send_packets (pDst p)
-                                       (@add_ghost_msg _ _ _ ghost_log_params (pDst p)
+                                       (@add_ghost_msg _ _ ghost_log_params (pDst p)
                                                        (post_ghost_state, r0) l4);
                 nwState := update name_eq_dec (nwState net) (pDst p)
                                   (post_ghost_state, r0) |}) as Hr0
@@ -380,11 +380,11 @@ Section RaftMsgRefinement.
               {|
                 nwPackets := (xs ++ ys) ++
                                        send_packets (pDst p)
-                                       (@add_ghost_msg _ _ _ ghost_log_params (pDst p)
+                                       (@add_ghost_msg _ _ ghost_log_params (pDst p)
                                                        (post_ghost_state, r0) l4)
                                        ++
                                        send_packets (pDst p)
-                                       (@add_ghost_msg _ _ _ ghost_log_params (pDst p)
+                                       (@add_ghost_msg _ _ ghost_log_params (pDst p)
                                                        (post_ghost_state, r1) l5);
                 nwState := update name_eq_dec (nwState net) (pDst p)
                                   (post_ghost_state, r1) |}) as Hr1 by
@@ -459,7 +459,7 @@ Section RaftMsgRefinement.
            (msg_refined_raft_intermediate_reachable
               {|
                 nwPackets := (nwPackets net) ++ send_packets h
-                                       (@add_ghost_msg _ _ _ ghost_log_params h
+                                       (@add_ghost_msg _ _ ghost_log_params h
                                                        (post_ghost_state, r0) l4);
                 nwState := update name_eq_dec (nwState net) h
                                   (post_ghost_state, r0) |}) as Hr0
@@ -469,11 +469,11 @@ Section RaftMsgRefinement.
               {|
                 nwPackets := (nwPackets net) ++
                                        send_packets h
-                                       (@add_ghost_msg _ _ _ ghost_log_params h
+                                       (@add_ghost_msg _ _ ghost_log_params h
                                                        (post_ghost_state, r0) l4)
                                        ++
                                        send_packets h
-                                       (@add_ghost_msg _ _ _ ghost_log_params h
+                                       (@add_ghost_msg _ _ ghost_log_params h
                                                        (post_ghost_state, r1) l6);
                 nwState := update name_eq_dec (nwState net) h
                                   (post_ghost_state, r1) |}) as Hr1 by
@@ -567,7 +567,7 @@ Section RaftMsgRefinement.
       repeat rewrite map_map.
 
 
-  Notation mgv_deghost := (@mgv_deghost _ _ _ ghost_log_params).
+  Notation mgv_deghost := (@mgv_deghost _ _ ghost_log_params).
   
   Theorem simulation_1 :
     forall net,
@@ -696,7 +696,7 @@ Section RaftMsgRefinement.
 
   Lemma mgv_deghost_packet_mgv_ghost_packet_partial_inverses :
     forall p,
-      (@mgv_deghost_packet _ _ _ ghost_log_params (mgv_ghost_packet p)) = p.
+      (@mgv_deghost_packet _ _ ghost_log_params (mgv_ghost_packet p)) = p.
   Proof using. 
     intros.
     unfold mgv_deghost_packet, mgv_ghost_packet.
@@ -722,7 +722,7 @@ Section RaftMsgRefinement.
       eapply MRRIR_step_failure; eauto.
     - break_exists. break_and.
       subst.
-      assert (msg_refined_raft_intermediate_reachable ({| nwPackets := (nwPackets x) ++ (@send_packets _ raft_msg_refined_multi_params h (@add_ghost_msg _ _ _ ghost_log_params h (update_elections_data_input h inp (nwState (mgv_deghost x) h), d) l));
+      assert (msg_refined_raft_intermediate_reachable ({| nwPackets := (nwPackets x) ++ (@send_packets _ raft_msg_refined_multi_params h (@add_ghost_msg _ _ ghost_log_params h (update_elections_data_input h inp (nwState (mgv_deghost x) h), d) l));
            nwState := st'
                                                        |})) by
           (unfold mgv_deghost in *; repeat break_match; simpl in *;
@@ -731,7 +731,7 @@ Section RaftMsgRefinement.
       pose proof map_subset _ _ mgv_deghost_packet
            (nwPackets x ++
                       @send_packets _ raft_msg_refined_multi_params h
-                      (@add_ghost_msg _ _ _ ghost_log_params h
+                      (@add_ghost_msg _ _ ghost_log_params h
                                      (update_elections_data_input h inp
                                                                   (nwState (mgv_deghost x) h), d) l)) (map mgv_ghost_packet ps').
       forwards.
@@ -770,7 +770,7 @@ Section RaftMsgRefinement.
       subst. simpl in *.
       repeat break_match. simpl in *.
       subst. simpl in *.
-      assert (msg_refined_raft_intermediate_reachable ({| nwPackets := (xs' ++ ys') ++ (@send_packets _ raft_msg_refined_multi_params (pDst p') (@add_ghost_msg _ _ _ ghost_log_params (pDst p') (update_elections_data_net (pDst p') (pSrc p') (snd (pBody p')) (nwState  (pDst p')), d) l));
+      assert (msg_refined_raft_intermediate_reachable ({| nwPackets := (xs' ++ ys') ++ (@send_packets _ raft_msg_refined_multi_params (pDst p') (@add_ghost_msg _ _ ghost_log_params (pDst p') (update_elections_data_net (pDst p') (pSrc p') (snd (pBody p')) (nwState  (pDst p')), d) l));
            nwState := st'
                                                        |})).
       { unfold mgv_deghost in *; repeat break_match; simpl in *.
@@ -781,7 +781,7 @@ Section RaftMsgRefinement.
       pose proof map_subset _ _ mgv_deghost_packet
            ((xs' ++ ys') ++
                       @send_packets _ raft_msg_refined_multi_params (pDst p')
-                      (@add_ghost_msg _ _ _ ghost_log_params (pDst p')
+                      (@add_ghost_msg _ _ ghost_log_params (pDst p')
                                       (update_elections_data_net (pDst p') (pSrc p')
                                                                  (snd (pBody p'))
                                                                  (nwState  (pDst p')), d) l)) (map mgv_ghost_packet ps').
@@ -819,7 +819,7 @@ Section RaftMsgRefinement.
         auto using packet_eq_dec.
     - break_exists. break_and.
       subst.
-      assert (msg_refined_raft_intermediate_reachable ({| nwPackets := (nwPackets x) ++ (@send_packets _ raft_msg_refined_multi_params h (@add_ghost_msg _ _ _ ghost_log_params h (gd, d') ms));
+      assert (msg_refined_raft_intermediate_reachable ({| nwPackets := (nwPackets x) ++ (@send_packets _ raft_msg_refined_multi_params h (@add_ghost_msg _ _ ghost_log_params h (gd, d') ms));
            nwState := st'
                                                        |})).
       { unfold mgv_deghost in *; repeat break_match; simpl in *.
@@ -829,7 +829,7 @@ Section RaftMsgRefinement.
       pose proof map_subset _ _ mgv_deghost_packet
            (nwPackets x ++
                       @send_packets _ raft_msg_refined_multi_params h
-                      (@add_ghost_msg _ _ _ ghost_log_params h
+                      (@add_ghost_msg _ _ ghost_log_params h
                                      (gd, d') ms)) (map mgv_ghost_packet ps').
       forwards.
       {
@@ -860,7 +860,7 @@ Section RaftMsgRefinement.
         auto using packet_eq_dec.
     - break_exists. break_and.
       subst.
-      assert (msg_refined_raft_intermediate_reachable ({| nwPackets := (nwPackets x) ++ (@send_packets _ raft_msg_refined_multi_params h (@add_ghost_msg _ _ _ ghost_log_params h (gd, d') ms));
+      assert (msg_refined_raft_intermediate_reachable ({| nwPackets := (nwPackets x) ++ (@send_packets _ raft_msg_refined_multi_params h (@add_ghost_msg _ _ ghost_log_params h (gd, d') ms));
            nwState := st'
                                                        |})).
       { unfold mgv_deghost in *; repeat break_match; simpl in *.
@@ -870,7 +870,7 @@ Section RaftMsgRefinement.
       pose proof map_subset _ _ mgv_deghost_packet
            (nwPackets x ++
                       @send_packets _ raft_msg_refined_multi_params h
-                      (@add_ghost_msg _ _ _ ghost_log_params h
+                      (@add_ghost_msg _ _ ghost_log_params h
                                      (gd, d') ms)) (map mgv_ghost_packet ps').
       forwards.
       {

--- a/raft-proofs/StateMachineSafetyProof.v
+++ b/raft-proofs/StateMachineSafetyProof.v
@@ -1078,9 +1078,9 @@ Section StateMachineSafetyProof.
   Qed.
 
   Lemma msg_deghost_spec' :
-    forall base multi failure ghost
+    forall base multi ghost
       (net : @network (@mgv_refined_base_params base)
-                      (@mgv_refined_multi_params base multi failure ghost)) h,
+                      (@mgv_refined_multi_params base multi ghost)) h,
       nwState (mgv_deghost net) h = nwState net h.
   Proof using. 
     unfold mgv_deghost.
@@ -1354,7 +1354,7 @@ Section StateMachineSafetyProof.
       msg_refined_raft_intermediate_reachable net ->
       (forall h', st' h' = update name_eq_dec (nwState net) h (gd, d) h') ->
       (forall p', In p' ps' -> In p' (nwPackets net) \/
-                         In p' (send_packets h (add_ghost_msg (params := ghost_log_params) h (gd, d) l))) ->
+                         In p' (send_packets h (add_ghost_msg (msg_ghost_params := ghost_log_params) h (gd, d) l))) ->
       commit_invariant (mkNetwork ps' st').
   Proof using rmri rri. 
     unfold msg_refined_raft_net_invariant_client_request, commit_invariant.
@@ -1535,7 +1535,7 @@ Section StateMachineSafetyProof.
     find_apply_lem_hyp in_mgv_ghost_packet.
     match goal with
       | _ : snd (pBody ?p) = ?x |- _ =>
-        assert (pBody (@mgv_deghost_packet _ _ _ ghost_log_params p) = x)
+        assert (pBody (@mgv_deghost_packet _ _ ghost_log_params p) = x)
           by (rewrite pBody_mgv_deghost_packet; auto)
     end.
     eapply state_machine_safety'_invariant; eauto.
@@ -1553,7 +1553,7 @@ Section StateMachineSafetyProof.
     find_apply_lem_hyp in_mgv_ghost_packet.
     match goal with
       | _ : snd (pBody ?p) = ?x |- _ =>
-        assert (pBody (@mgv_deghost_packet _ _ _ ghost_log_params p) = x)
+        assert (pBody (@mgv_deghost_packet _ _ ghost_log_params p) = x)
           by (rewrite pBody_mgv_deghost_packet; auto)
     end.
     find_eapply_lem_hyp entries_sorted_nw_invariant; eauto.
@@ -2672,7 +2672,7 @@ Section StateMachineSafetyProof.
       nwState net h = (gd, d) ->
       (forall h', st' h' = update name_eq_dec (nwState net) h (gd, d') h') ->
       (forall p,
-          In p ps' -> In p (nwPackets net) \/ In p (send_packets h (add_ghost_msg (params := ghost_log_params) h (gd, d') ms))) ->
+          In p ps' -> In p (nwPackets net) \/ In p (send_packets h (add_ghost_msg (msg_ghost_params := ghost_log_params) h (gd, d') ms))) ->
       commit_invariant {| nwPackets := ps'; nwState := st' |}.
   Proof using rmri miaei. 
     unfold commit_invariant.

--- a/raft/RaftMsgRefinementInterface.v
+++ b/raft/RaftMsgRefinementInterface.v
@@ -18,7 +18,7 @@ Section RaftMsgRefinementInterface.
 
   Definition write_ghost_log (h : name) (st : @data raft_refined_base_params) : ghost_log := log (snd st).
 
-  Instance ghost_log_params : MsgGhostFailureParams raft_refined_failure_params :=
+  Instance ghost_log_params : MsgGhostMultiParams raft_refined_multi_params :=
     {| ghost_msg := ghost_log ;
        ghost_msg_eq_dec := ghost_log_eq_dec ;
        ghost_msg_default := [] ;
@@ -57,7 +57,7 @@ Section RaftMsgRefinementInterface.
         nwPackets net = xs ++ p :: ys ->
         (forall h, st' h = update name_eq_dec (nwState net) (pDst p) (gd, d) h) ->
         (forall p', In p' ps' -> In p' (xs ++ ys) \/
-                           In p' (send_packets (pDst p) (@add_ghost_msg _ _ _ ghost_log_params (pDst p) (gd, d) l))) ->
+                           In p' (send_packets (pDst p) (@add_ghost_msg _ _ ghost_log_params (pDst p) (gd, d) l))) ->
         msg_refined_raft_intermediate_reachable (mkNetwork ps' st')
   | MRRIR_doLeader :
       forall net st' ps' h os gd d d' ms,
@@ -123,7 +123,7 @@ Section RaftMsgRefinementInterface.
       nwPackets net = xs ++ p :: ys ->
       (forall h, st' h = update name_eq_dec (nwState net) (pDst p) (gd, d) h) ->
       (forall p', In p' ps' -> In p' (xs ++ ys) \/
-                         In p' (send_packets (pDst p) (@add_ghost_msg _ _ _ ghost_log_params (pDst p) (gd, d) m))) ->
+                         In p' (send_packets (pDst p) (@add_ghost_msg _ _ ghost_log_params (pDst p) (gd, d) m))) ->
       P (mkNetwork ps' st').
 
   Definition msg_refined_raft_net_invariant_request_vote (P : network -> Prop) :=
@@ -243,7 +243,7 @@ Section RaftMsgRefinementInterface.
       nwPackets net = xs ++ p :: ys ->
       (forall h, st' h = update name_eq_dec (nwState net) (pDst p) (gd, d) h) ->
       (forall p', In p' ps' -> In p' (xs ++ ys) \/
-                         In p' (send_packets (pDst p) (@add_ghost_msg _ _ _ ghost_log_params (pDst p) (gd, d) m))) ->
+                         In p' (send_packets (pDst p) (@add_ghost_msg _ _ ghost_log_params (pDst p) (gd, d) m))) ->
       P (mkNetwork ps' st').
 
   Definition msg_refined_raft_net_invariant_request_vote' (P : network -> Prop) :=

--- a/raft/RaftRefinementInterface.v
+++ b/raft/RaftRefinementInterface.v
@@ -145,7 +145,7 @@ Section RaftRefinementInterface.
       | ClientRequest client id c => update_elections_data_client_request me st client id c
     end.
 
-  Instance elections_ghost_params : GhostFailureParams failure_params :=
+  Instance elections_ghost_params : GhostMultiParams multi_params :=
     {
       ghost_data := electionsData ;
       ghost_init := {| votes := [] ; votesWithLog := []; cronies := fun _ => [];


### PR DESCRIPTION
This should not be merged until the corresponding [Verdi PR](https://github.com/uwplse/verdi/pull/114) has been merged.