### PR TITLE
Simplify OPAM packages for Travis

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -12,6 +12,9 @@ case $MODE in
   proofalytics)
     opam pin add verdi-raft-proofalytics . --yes --verbose
     ;;
+  checkproofs)
+    opam pin add verdi-raft-checkproofs . --yes --verbose
+    ;;
   vard)
     opam pin add vard . --yes --verbose
     ;;

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -15,9 +15,6 @@ case $MODE in
   vard)
     opam pin add vard . --yes --verbose
     ;;
-  vard-test)
-    OPAMBUILDTEST=1 opam pin add vard . --yes --verbose
-    ;;
   *)
     opam pin add verdi-raft . --yes --verbose
     ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - COQ_VERSION=8.6
   matrix:
     - MODE=build
+    - MODE=checkproofs
     - MODE=vard OPAMBUILDTEST=1
 script: bash -ex .travis-ci.sh
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - COQ_VERSION=8.6
   matrix:
     - MODE=build
-    - MODE=vard-test
+    - MODE=vard OPAMBUILDTEST=1
 script: bash -ex .travis-ci.sh
 sudo: false
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ default: Makefile.coq
 quick: Makefile.coq
 	$(MAKE) -f Makefile.coq quick
 
+checkproofs: Makefile.coq
+	$(MAKE) -f Makefile.coq quick
+	$(MAKE) -f Makefile.coq checkproofs
+
 install: Makefile.coq
 	$(MAKE) -f Makefile.coq install
 
@@ -79,4 +83,4 @@ lint:
 distclean: clean
 	rm -f _CoqProject
 
-.PHONY: default quick install clean vard vard-test lint proofalytics distclean $(MLFILES)
+.PHONY: default quick install clean vard vard-test lint proofalytics distclean checkproofs $(MLFILES)

--- a/vard.opam
+++ b/vard.opam
@@ -1,5 +1,4 @@
 opam-version: "1.2"
-name: "vard"
 version: "dev"
 maintainer: "palmskog@gmail.com"
 

--- a/verdi-raft-checkproofs.opam
+++ b/verdi-raft-checkproofs.opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+name: "verdi-raft-checkproofs"
+version: "dev"
+maintainer: "palmskog@gmail.com"
+
+homepage: "https://github.com/uwplse/verdi-raft"
+dev-repo: "https://github.com/uwplse/verdi-raft.git"
+bug-reports: "https://github.com/uwplse/verdi-raft/issues"
+license: "BSD"
+
+build: [
+  [ "./configure" ]
+  [ make "checkproofs" "J=%{jobs}%" ]
+]
+depends: [
+  "coq" {>= "8.6" & < "8.7~"}
+  "verdi" {= "dev"}
+  "StructTact" {= "dev"}
+]
+
+authors: [
+  "James Wilcox <>"
+  "Doug Woos <>"
+  "Pavel Panchekha <>"
+  "Zachary Tatlock <>"
+  "Steve Anton <>"
+  "Karl Palmskog <>"
+  "Ryan Doenges <>"
+]

--- a/verdi-raft-checkproofs.opam
+++ b/verdi-raft-checkproofs.opam
@@ -1,5 +1,4 @@
 opam-version: "1.2"
-name: "verdi-raft-checkproofs"
 version: "dev"
 maintainer: "palmskog@gmail.com"
 

--- a/verdi-raft-proofalytics.opam
+++ b/verdi-raft-proofalytics.opam
@@ -1,5 +1,4 @@
 opam-version: "1.2"
-name: "verdi-raft-proofalytics"
 version: "dev"
 maintainer: "palmskog@gmail.com"
 

--- a/verdi-raft.opam
+++ b/verdi-raft.opam
@@ -1,5 +1,4 @@
 opam-version: "1.2"
-name: "verdi-raft"
 version: "dev"
 maintainer: "palmskog@gmail.com"
 
@@ -19,6 +18,7 @@ depends: [
   "verdi" {= "dev"}
   "StructTact" {= "dev"}
 ]
+
 tags: [
   "category:Computer Science/Concurrent Systems and Protocols/Theory of concurrent systems"
   "keyword:program verification"


### PR DESCRIPTION
Simplification of local OPAM packages for Travis. Added experimental `checkproofs` target that performs embarrassingly parallel proving.