### PR TITLE
Correct handling of client ids

### DIFF
--- a/extraction/vard-serialized/bench/vard.py
+++ b/extraction/vard-serialized/bench/vard.py
@@ -1,3 +1,4 @@
+import random
 import socket
 import re
 import uuid
@@ -36,6 +37,7 @@ class Client(object):
     response_re = re.compile(r'Response\W+([0-9]+)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)')
 
     def __init__(self, host, port, sock=None):
+        self.client_id = random.randint(0, 2**31 - 1)
         if not sock:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.sock.connect((host, port))
@@ -54,7 +56,7 @@ class Client(object):
         return str(arg)
 
     def send_command(self, cmd, arg1=None, arg2=None, arg3=None):
-        msg = str(self.request_id) + ' ' + cmd + ' ' + ' '.join(map(self.serialize, (arg1, arg2, arg3)))
+        msg = str(self.client_id) + ' ' + str(self.request_id) + ' ' + cmd + ' ' + ' '.join(map(self.serialize, (arg1, arg2, arg3)))
         n = self.sock.send(pack("<I", len(msg)))
         if n < 4:
             raise SendError

--- a/extraction/vard-serialized/ml/VarDSerializedArrangement.ml
+++ b/extraction/vard-serialized/ml/VarDSerializedArrangement.ml
@@ -84,8 +84,5 @@ module VarDArrangement (P : VarDParams) = struct
     flush_all ()
   let debug_timeout (s : state) = ()
   let debug_input s inp = ()
-  let create_client_id () =
-    let upper_bound = 1073741823 in
-    Random.int upper_bound
   let string_of_client_id = string_of_int
 end

--- a/extraction/vard-serialized/ml/VarDSerializedSerialization.ml
+++ b/extraction/vard-serialized/ml/VarDSerializedSerialization.ml
@@ -33,26 +33,25 @@ let serializeOutput out =
   let (c, s) = outputToString out in
   (c, Bytes.of_string s)
 
-let deserializeInp buf =
-  let i = Bytes.to_string buf in
-  let inp = String.trim i in
-  let r = regexp "\\([0-9]+\\) \\([A-Z]+\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\)[^/A-za-z0-9]*" in
+let deserializeInp i =
+  let inp = String.trim (Bytes.to_string i) in
+  let r = regexp "\\([0-9]+\\) \\([0-9]+\\) \\([A-Z]+\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\)[^/A-za-z0-9]*" in
   if string_match r inp 0 then
     (match (matched_group 1 inp, matched_group 2 inp,
             matched_group 3 inp, matched_group 4 inp,
-            matched_group 5 inp) with
-     | (i, "GET", k, _, _) -> Some (int_of_string i, Get (char_list_of_string k))
-     | (i, "DEL", k, _, _) -> Some (int_of_string i, Del (char_list_of_string k))
-     | (i, "PUT", k, v, _) -> Some (int_of_string i, Put ((char_list_of_string k), (char_list_of_string v)))
-     | (i, "CAD", k, o, _) -> Some (int_of_string i, CAD (char_list_of_string k, char_list_of_string o))
-     | (i, "CAS", k, "-", v) -> Some (int_of_string i, CAS ((char_list_of_string k), None, (char_list_of_string v)))
-     | (i, "CAS", k, o, v) -> Some (int_of_string i, CAS ((char_list_of_string k), Some (char_list_of_string o), (char_list_of_string v)))
+            matched_group 5 inp, matched_group 6 inp) with
+     | (c, r, "GET", k, _, _) -> Some (int_of_string c, int_of_string r, Get (char_list_of_string k))
+     | (c, r, "DEL", k, _, _) -> Some (int_of_string c, int_of_string r, Del (char_list_of_string k))
+     | (c, r, "PUT", k, v, _) -> Some (int_of_string c, int_of_string r, Put ((char_list_of_string k), (char_list_of_string v)))
+     | (c, r, "CAD", k, o, _) -> Some (int_of_string c, int_of_string r, CAD (char_list_of_string k, char_list_of_string o))
+     | (c, r, "CAS", k, "-", v) -> Some (int_of_string c, int_of_string r, CAS ((char_list_of_string k), None, (char_list_of_string v)))
+     | (c, r, "CAS", k, o, v) -> Some (int_of_string c, int_of_string r, CAS ((char_list_of_string k), Some (char_list_of_string o), (char_list_of_string v)))
      | _ -> None)
   else
     (print_endline "No match" ; None)
 
-let deserializeInput inp client_id =
+let deserializeInput inp =
   match deserializeInp inp with
-  | Some (request_id, input) ->
-    Some (ClientRequest (client_id, request_id, Obj.magic input))
+  | Some (client_id, request_id, input) ->
+    Some (client_id, ClientRequest (client_id, request_id, Obj.magic input))
   | None -> None

--- a/extraction/vard/bench/vard.py
+++ b/extraction/vard/bench/vard.py
@@ -1,3 +1,4 @@
+import random
 import socket
 import re
 import uuid
@@ -36,6 +37,7 @@ class Client(object):
     response_re = re.compile(r'Response\W+([0-9]+)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)')
 
     def __init__(self, host, port, sock=None):
+        self.client_id = random.randint(0, 2**31 - 1)
         if not sock:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.sock.connect((host, port))
@@ -54,7 +56,7 @@ class Client(object):
         return str(arg)
 
     def send_command(self, cmd, arg1=None, arg2=None, arg3=None):
-        msg = str(self.request_id) + ' ' + cmd + ' ' + ' '.join(map(self.serialize, (arg1, arg2, arg3)))
+        msg = str(self.client_id) + ' ' + str(self.request_id) + ' ' + cmd + ' ' + ' '.join(map(self.serialize, (arg1, arg2, arg3)))
         n = self.sock.send(pack("<I", len(msg)))
         if n < 4:
             raise SendError

--- a/extraction/vard/ml/VarDArrangement.ml
+++ b/extraction/vard/ml/VarDArrangement.ml
@@ -80,8 +80,5 @@ module VarDArrangement (P : VarDParams) = struct
      | _ -> ()); flush_all ()
   let debug_timeout (s : state) = ()
   let debug_input s inp = ()
-  let create_client_id () =
-    let upper_bound = 1073741823 in
-    Random.int upper_bound
   let string_of_client_id = string_of_int
 end

--- a/extraction/vard/ml/VarDSerialization.ml
+++ b/extraction/vard/ml/VarDSerialization.ml
@@ -33,25 +33,25 @@ let serializeOutput out =
 
 let deserializeInp i =
   let inp = String.trim (Bytes.to_string i) in
-  let r = regexp "\\([0-9]+\\) \\([A-Z]+\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\)[^/A-za-z0-9]*" in
+  let r = regexp "\\([0-9]+\\) \\([0-9]+\\) \\([A-Z]+\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\) +\\([/A-za-z0-9]+\\|-\\)[^/A-za-z0-9]*" in
   if string_match r inp 0 then
     (match (matched_group 1 inp, matched_group 2 inp,
             matched_group 3 inp, matched_group 4 inp,
-            matched_group 5 inp) with
-     | (i, "GET", k, _, _) -> Some (int_of_string i, Get (char_list_of_string k))
-     | (i, "DEL", k, _, _) -> Some (int_of_string i, Del (char_list_of_string k))
-     | (i, "PUT", k, v, _) -> Some (int_of_string i, Put ((char_list_of_string k), (char_list_of_string v)))
-     | (i, "CAD", k, o, _) -> Some (int_of_string i, CAD (char_list_of_string k, char_list_of_string o))
-     | (i, "CAS", k, "-", v) -> Some (int_of_string i, CAS ((char_list_of_string k), None, (char_list_of_string v)))
-     | (i, "CAS", k, o, v) -> Some (int_of_string i, CAS ((char_list_of_string k), Some (char_list_of_string o), (char_list_of_string v)))
+            matched_group 5 inp, matched_group 6 inp) with
+     | (c, r, "GET", k, _, _) -> Some (int_of_string c, int_of_string r, Get (char_list_of_string k))
+     | (c, r, "DEL", k, _, _) -> Some (int_of_string c, int_of_string r, Del (char_list_of_string k))
+     | (c, r, "PUT", k, v, _) -> Some (int_of_string c, int_of_string r, Put ((char_list_of_string k), (char_list_of_string v)))
+     | (c, r, "CAD", k, o, _) -> Some (int_of_string c, int_of_string r, CAD (char_list_of_string k, char_list_of_string o))
+     | (c, r, "CAS", k, "-", v) -> Some (int_of_string c, int_of_string r, CAS ((char_list_of_string k), None, (char_list_of_string v)))
+     | (c, r, "CAS", k, o, v) -> Some (int_of_string c, int_of_string r, CAS ((char_list_of_string k), Some (char_list_of_string o), (char_list_of_string v)))
      | _ -> None)
   else
     (print_endline "No match" ; None)
 
-let deserializeInput inp client_id =
+let deserializeInput inp =
   match deserializeInp inp with
-  | Some (request_id, input) ->
-    Some (ClientRequest (client_id, request_id, Obj.magic input))
+  | Some (client_id, request_id, input) ->
+    Some (client_id, ClientRequest (client_id, request_id, Obj.magic input))
   | None -> None
 
 let deserializeMsg (b : bytes) : VarDRaft.msg = Marshal.from_bytes b 0


### PR DESCRIPTION
See the accompanying PR on verdi-runtime for more. Basically, in order
to do request deduplication we need clients to have the same id across
servers, and right now they almost definitely won't. The clients now
send their client id with every request, and vard is patched to work
with the new shim.

We should migrate these changes to the DiskOp shim as well. When
that's done, we can also change the other versions of vard that use
that shim.