### PR TITLE
client id type specified in Raft parameters

### DIFF
--- a/extraction/vard-log/ml/VarDLogSerialization.ml
+++ b/extraction/vard-log/ml/VarDLogSerialization.ml
@@ -7,10 +7,10 @@ open Util
 let outputToString out =
   match Obj.magic out with
   | NotLeader (client_id, request_id) ->
-    (client_id, sprintf "NotLeader %s" (string_of_int request_id))
+    (Obj.magic client_id, sprintf "NotLeader %s" (string_of_int request_id))
   | ClientResponse (client_id, request_id, o) ->
      let Response (k, value, old) = (Obj.magic o) in
-     (client_id,
+     (Obj.magic client_id,
       match (value, old) with
       | Some v, Some o ->
          sprintf "Response %s %s %s %s"
@@ -58,7 +58,7 @@ let deserializeInp buf =
 let deserializeInput inp client_id =
   match deserializeInp inp with
   | Some (request_id, input) ->
-    Some (ClientRequest (client_id, request_id, Obj.magic input))
+    Some (ClientRequest (Obj.magic client_id, request_id, Obj.magic input))
   | None -> None
 
 let deserializeClientId b =

--- a/extraction/vard-serialized-log/ml/VarDSerializedLogSerialization.ml
+++ b/extraction/vard-serialized-log/ml/VarDSerializedLogSerialization.ml
@@ -7,10 +7,10 @@ open Util
 let outputToString out =
   match Obj.magic out with
   | NotLeader (client_id, request_id) ->
-    (client_id, sprintf "NotLeader %s" (string_of_int request_id))
+    (Obj.magic client_id, sprintf "NotLeader %s" (string_of_int request_id))
   | ClientResponse (client_id, request_id, o) ->
      let Response (k, value, old) = (Obj.magic o) in
-     (client_id,
+     (Obj.magic client_id,
       match (value, old) with
       | Some v, Some o ->
          sprintf "Response %s %s %s %s"
@@ -58,7 +58,7 @@ let deserializeInp buf =
 let deserializeInput inp client_id =
   match deserializeInp inp with
   | Some (request_id, input) ->
-    Some (ClientRequest (client_id, request_id, Obj.magic input))
+    Some (ClientRequest (Obj.magic client_id, request_id, Obj.magic input))
   | None -> None
 
 let deserializeClientId b =

--- a/extraction/vard-serialized/ml/VarDSerializedSerialization.ml
+++ b/extraction/vard-serialized/ml/VarDSerializedSerialization.ml
@@ -7,10 +7,10 @@ open Util
 let outputToString out =
   match Obj.magic out with
   | NotLeader (client_id, request_id) ->
-    (client_id, sprintf "NotLeader %s" (string_of_int request_id))
+    (Obj.magic client_id, sprintf "NotLeader %s" (string_of_int request_id))
   | ClientResponse (client_id, request_id, o) ->
      let Response (k, value, old) = (Obj.magic o) in
-     (client_id,
+     (Obj.magic client_id,
       match (value, old) with
       | Some v, Some o ->
          sprintf "Response %s %s %s %s"
@@ -56,7 +56,7 @@ let deserializeInp buf =
 let deserializeInput inp client_id =
   match deserializeInp inp with
   | Some (request_id, input) ->
-    Some (ClientRequest (client_id, request_id, Obj.magic input))
+    Some (ClientRequest (Obj.magic client_id, request_id, Obj.magic input))
   | None -> None
 
 let deserializeClientId b =

--- a/extraction/vard-serialized/test/VarDSerializedSerializationTest.ml
+++ b/extraction/vard-serialized/test/VarDSerializedSerializationTest.ml
@@ -6,12 +6,12 @@ let tear_down () text_ctxt = ()
 
 let test_serialize_output_not_leader text_ctxt =
   assert_equal (2, Bytes.of_string "NotLeader 15")
-    (VarDSerializedSerialization.serializeOutput (VarDRaftSerialized.NotLeader (2, 15)))
+    (VarDSerializedSerialization.serializeOutput (VarDRaftSerialized.NotLeader (Obj.magic 2, 15)))
 
 let test_serialize_output_client_response test_ctxt =
   let o = VarDRaftSerialized.Response (char_list_of_string "awesome", None, None) in
   assert_equal (3, Bytes.of_string "Response 34 awesome - -")
-    (VarDSerializedSerialization.serializeOutput (VarDRaftSerialized.ClientResponse (3, 34, (Obj.magic o))))
+    (VarDSerializedSerialization.serializeOutput (VarDRaftSerialized.ClientResponse (Obj.magic 3, 34, (Obj.magic o))))
   
 let test_list =
   [

--- a/extraction/vard/ml/VarDSerialization.ml
+++ b/extraction/vard/ml/VarDSerialization.ml
@@ -8,10 +8,10 @@ let serializeOutput out =
   let (c, os) =
     match Obj.magic out with
     | NotLeader (client_id, request_id) ->
-       (client_id, sprintf "NotLeader %s" (string_of_int request_id))
+       (Obj.magic client_id, sprintf "NotLeader %s" (string_of_int request_id))
     | ClientResponse (client_id, request_id, o) ->
        let Response (k, value, old) = Obj.magic o in
-       (client_id,
+       (Obj.magic client_id,
         match value, old with
         | Some v, Some o ->
            sprintf "Response %s %s %s %s"
@@ -55,7 +55,7 @@ let deserializeInp i =
 let deserializeInput inp client_id =
   match deserializeInp inp with
   | Some (request_id, input) ->
-    Some (ClientRequest (client_id, request_id, Obj.magic input))
+    Some (ClientRequest (Obj.magic client_id, request_id, Obj.magic input))
   | None -> None
 
 let deserializeMsg (b : bytes) : VarDRaft.msg = Marshal.from_bytes b 0

--- a/extraction/vard/test/VarDSerializationTest.ml
+++ b/extraction/vard/test/VarDSerializationTest.ml
@@ -6,13 +6,13 @@ let tear_down () text_ctxt = ()
 
 let test_serialize_output_not_leader text_ctxt =
   assert_equal (2, Bytes.of_string "NotLeader 15")
-    (VarDSerialization.serializeOutput (VarDRaft.NotLeader (2, 15)))
+    (VarDSerialization.serializeOutput (VarDRaft.NotLeader (Obj.magic 2, 15)))
 
 let test_serialize_output_client_response test_ctxt =
   let o = VarDRaft.Response (char_list_of_string "awesome", None, None) in
   assert_equal (3, Bytes.of_string "Response 34 awesome - -")
-    (VarDSerialization.serializeOutput (VarDRaft.ClientResponse (3, 34, (Obj.magic o))))
-  
+    (VarDSerialization.serializeOutput (VarDRaft.ClientResponse (Obj.magic 3, 34, (Obj.magic o))))
+
 let test_list =
   [
     "serialize NotLeader", test_serialize_output_not_leader;

--- a/raft-proofs/AppliedImpliesInputProof.v
+++ b/raft-proofs/AppliedImpliesInputProof.v
@@ -28,7 +28,8 @@ Section AppliedImpliesInputProof.
   Qed.
 
   Section inner.
-    Variables client id : nat.
+    Variable client : clientId.
+    Variable id : nat.
     Variable i : input.
 
     Lemma applied_implies_input_update_split :
@@ -332,7 +333,7 @@ Section AppliedImpliesInputProof.
       {correct_entry client id i e} +
       {~ correct_entry client id i e}.
       unfold correct_entry.
-      destruct (eq_nat_dec (eClient e) client),
+      destruct (clientId_eq_dec (eClient e) client),
                (eq_nat_dec (eId e) id),
                (input_eq_dec (eInput e) i); intuition.
     Defined.

--- a/raft-proofs/CausalOrderPreservedProof.v
+++ b/raft-proofs/CausalOrderPreservedProof.v
@@ -20,8 +20,12 @@ Section CausalOrderPreserved.
   Context {aemi : applied_entries_monotonic_interface}.
 
   Section inner.
-  Variables client id client' id' : nat.
+  Variable client : clientId.
+  Variable id : nat.
+  Variable client' : clientId.
+  Variable id' : nat.
 
+  (* FIXME: move to StructTact *)
   Lemma before_func_app_necessary :
     forall A f g (l : list A) l',
       ~ before_func f g l ->
@@ -43,14 +47,14 @@ Section CausalOrderPreserved.
     intuition.
     break_exists. unfold in_input_trace in *.
     break_exists. do_in_app. intuition;
-      [find_apply_hyp_hyp; simpl in *; repeat (do_bool; intuition)|].
+      [find_apply_hyp_hyp; simpl in *; break_if; repeat (do_bool; intuition)|].
     invcs H0; intuition.
     - break_if; congruence.
     - find_inversion; try congruence.
       repeat (do_bool; intuition).
+      break_if; try congruence.
     - find_inversion.
   Qed.
-
 
   Lemma output_before_input_key_in_output_trace :
     forall tr,
@@ -75,17 +79,16 @@ Section CausalOrderPreserved.
     intros. unfold in_applied_entries, entries_ordered in *.
     induction (applied_entries (nwState net)); simpl in *; break_exists; intuition.
     - subst. left. unfold has_key. break_match.
-      simpl. repeat (do_bool; intuition).
+      simpl. break_if; repeat (do_bool; intuition).
     - right. intuition.
       + apply Bool.not_true_iff_false. intuition.
         find_false.
-        unfold has_key in *. break_match; simpl in *; repeat (do_bool; intuition).
+        unfold has_key in *. break_match; simpl in *; break_if; repeat (do_bool; intuition); try congruence.
         subst. eexists; intuition; eauto.
       + eapply IHl.
         * eexists; intuition; eauto.
         * intuition. find_false. break_exists_exists. intuition.
   Qed.
-
 
   Lemma in_applied_entries_applied_implies_input_state :
     forall net,

--- a/raft-proofs/InputBeforeOutputProof.v
+++ b/raft-proofs/InputBeforeOutputProof.v
@@ -33,13 +33,14 @@ Section InputBeforeOutput.
   Context {uii : unique_indices_interface}.
 
   Section inner.
-  Variables client id : nat.
+  Variable client : clientId.
+  Variable id : nat.
 
   Fixpoint client_id_in l :=
     match l with
       | [] => false
       | e :: l' =>
-        if (andb (eClient e =? client)
+        if (andb (if clientId_eq_dec (eClient e) client then true else false)
                  (eId e =? id)) then
           true
         else
@@ -53,7 +54,7 @@ Section InputBeforeOutput.
   Proof using. 
     intros. unfold in_applied_entries.
     induction (applied_entries (nwState net)); simpl in *; try congruence.
-    break_if; do_bool; intuition; do_bool; eauto;
+    break_if; break_if; do_bool; intuition; try congruence; do_bool; eauto;
     break_exists_exists; intuition.
   Qed.
 
@@ -66,8 +67,8 @@ Section InputBeforeOutput.
     induction (applied_entries (nwState net)); simpl in *; try congruence; intuition.
     - break_exists; intuition.
     - break_if; try congruence.
-      do_bool.
-      break_exists; intuition; do_bool; subst; eauto.
+      do_bool.      
+      break_exists; break_if; try congruence; intuition; do_bool; subst; eauto.
   Qed.
 
   Lemma doGenericServer_applied_entries :
@@ -140,7 +141,6 @@ Section InputBeforeOutput.
         find_copy_apply_lem_hyp removeAfterIndex_in.
         find_apply_lem_hyp removeAfterIndex_In_le; eauto.
   Qed.
-
   
   Lemma findAtIndex_max_thing :
     forall net h e i,
@@ -600,7 +600,7 @@ Section InputBeforeOutput.
     - unfold in_input_trace in *.
       break_exists. simpl in *. intuition.
       + subst. unfold input_before_output. simpl.
-        left. do_bool; intuition; do_bool; auto.
+        left. do_bool; break_if; intuition; do_bool; auto.
       + unfold input_before_output. simpl. right. intuition.
         * unfold key_in_output_trace in *. 
           apply Bool.not_true_iff_false. intuition.
@@ -622,7 +622,7 @@ Section InputBeforeOutput.
   Proof using. 
     intros. induction tr; simpl in *.
     -unfold input_before_output. simpl in *.
-     left. repeat (do_bool; intuition).
+     left. break_if; repeat (do_bool; intuition).
     - unfold input_before_output. simpl. right. intuition.
       + unfold key_in_output_trace in *.
         apply Bool.not_true_iff_false. intuition.

--- a/raft-proofs/LeaderLogsVotesWithLogProof.v
+++ b/raft-proofs/LeaderLogsVotesWithLogProof.v
@@ -81,7 +81,7 @@ Section LeaderLogsVotesWithLog.
   Lemma update_elections_data_request_vote_votesWithLog_old :
     forall (h : name)
       (st : electionsData *
-            RaftState.raft_data term name entry logIndex serverType data output)
+            RaftState.raft_data term name entry logIndex serverType data clientId output)
       (t : nat) (src : fin N) (lli llt : nat)
       (t' : term) (h' : name) (l' : list entry),
       In (t', h', l') (votesWithLog (fst st)) ->

--- a/raft-proofs/OutputImpliesAppliedProof.v
+++ b/raft-proofs/OutputImpliesAppliedProof.v
@@ -26,7 +26,8 @@ Section OutputImpliesApplied.
   Context {misi : max_index_sanity_interface}.
 
   Section inner.
-  Variables client id : nat.
+    Variable client : clientId.
+    Variable id : nat.
 
   Lemma in_output_changed :
     forall tr o,

--- a/raft/AppliedImpliesInputInterface.v
+++ b/raft/AppliedImpliesInputInterface.v
@@ -8,7 +8,8 @@ Section AppliedImpliesInputInterface.
   Context {raft_params : RaftParams orig_base_params}.
 
   Section inner.
-    Variables client id : nat.
+    Variable client : clientId.
+    Variable id : nat.
     Variable i : input.
 
     Definition correct_entry (e : entry) : Prop :=

--- a/raft/CausalOrderPreservedInterface.v
+++ b/raft/CausalOrderPreservedInterface.v
@@ -8,7 +8,10 @@ Section CausalOrderPreserved.
   Context {raft_params : RaftParams orig_base_params}.
 
   Section inner.
-  Variables client id client' id' : nat.
+  Variable client : clientId.
+  Variable id : nat.
+  Variable client' : clientId.
+  Variable id' : nat.
 
   Definition output_before_input (tr : list (name * (raft_input + list raft_output))) :=
     before_func (is_output_with_key client id) (is_input_with_key client' id') tr.

--- a/raft/CommonDefinitions.v
+++ b/raft/CommonDefinitions.v
@@ -69,25 +69,25 @@ Section CommonDefinitions.
     Definition execute_log (log : list entry) : (list (input * output) * data) :=
       execute_log' log init [].
 
-    Definition key : Type := nat * nat.
+    Definition key : Type := clientId * nat.
 
     Definition key_eq_dec : forall x y : key, {x = y} + {x <> y}.
     Proof using. 
-      decide equality; auto using eq_nat_dec.
+      decide equality; auto using clientId_eq_dec, eq_nat_dec.
     Qed.
 
     Definition key_of (e : entry) :=
       (eClient e, eId e).
 
-    Fixpoint deduplicate_log' (log : list entry) (ks : list (nat * nat)) : list entry :=
+    Fixpoint deduplicate_log' (log : list entry) (ks : list (clientId * nat)) : list entry :=
       match log with
         | [] => []
         | e :: es =>
-          match assoc eq_nat_dec ks (eClient e) with
+          match assoc clientId_eq_dec ks (eClient e) with
             | Some n => if n <? eId e
-                        then e :: deduplicate_log' es (assoc_set eq_nat_dec ks (eClient e) (eId e))
+                        then e :: deduplicate_log' es (assoc_set clientId_eq_dec ks (eClient e) (eId e))
                         else deduplicate_log' es ks
-            | None => e :: deduplicate_log' es (assoc_set eq_nat_dec ks (eClient e) (eId e))
+            | None => e :: deduplicate_log' es (assoc_set clientId_eq_dec ks (eClient e) (eId e))
           end
       end.
 

--- a/raft/InputBeforeOutputInterface.v
+++ b/raft/InputBeforeOutputInterface.v
@@ -7,7 +7,8 @@ Section InputBeforeOutputInterface.
   Context {raft_params : RaftParams orig_base_params}.
 
   Section inner.
-  Variables client id : nat.
+  Variable client : clientId.
+  Variables id : nat.
 
   Definition input_before_output (tr : list (name * (raft_input + list raft_output))) :=
     before_func (is_input_with_key client id) (is_output_with_key client id) tr.

--- a/raft/OutputGreatestIdInterface.v
+++ b/raft/OutputGreatestIdInterface.v
@@ -10,7 +10,8 @@ Section OutputGreatestId.
 
   Section inner.
 
-  Variables client id : nat.
+  Variable client : clientId.
+  Variable id : nat.
 
 
   Definition greatest_id_for_client (net : network) : Prop :=

--- a/raft/OutputImpliesAppliedInterface.v
+++ b/raft/OutputImpliesAppliedInterface.v
@@ -10,7 +10,8 @@ Section OutputImpliesApplied.
 
   Section inner.
 
-  Variables client id : nat.
+  Variable client : clientId.
+  Variable id : nat.
 
 
   Definition in_applied_entries (net : network) : Prop :=

--- a/raft/RaftState.v
+++ b/raft/RaftState.v
@@ -9,6 +9,7 @@ Section RaftState.
   Variable logIndex : Type.
   Variable serverType : Type.
   Variable stateMachineData : Type.
+  Variable clientId : Type.
   Variable output : Type.
 
   Record raft_data :=
@@ -31,7 +32,7 @@ Section RaftState.
         (* whoami *)
         type : serverType;
         (* client request state *)
-        clientCache : list (nat * (nat * output));
+        clientCache : list (clientId * (nat * output));
         (* ghost variables *)
         electoralVictories : list (term * list name * list entry)
       }.
@@ -69,59 +70,59 @@ End RaftState.
 
 
 
-Notation "{[ a 'with' 'currentTerm' := v ]}" := (set_raft_data_currentTerm  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'currentTerm' := v ]}" := (set_raft_data_currentTerm  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'votedFor' := v ]}" := (set_raft_data_votedFor  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'votedFor' := v ]}" := (set_raft_data_votedFor  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'leaderId' := v ]}" := (set_raft_data_leaderId  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'leaderId' := v ]}" := (set_raft_data_leaderId  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'log' := v ]}" := (set_raft_data_log  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'log' := v ]}" := (set_raft_data_log  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'commitIndex' := v ]}" := (set_raft_data_commitIndex  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'commitIndex' := v ]}" := (set_raft_data_commitIndex  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'lastApplied' := v ]}" := (set_raft_data_lastApplied  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'lastApplied' := v ]}" := (set_raft_data_lastApplied  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'stateMachine' := v ]}" := (set_raft_data_stateMachine  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'stateMachine' := v ]}" := (set_raft_data_stateMachine  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'nextIndex' := v ]}" := (set_raft_data_nextIndex  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'nextIndex' := v ]}" := (set_raft_data_nextIndex  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'matchIndex' := v ]}" := (set_raft_data_matchIndex  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'matchIndex' := v ]}" := (set_raft_data_matchIndex  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'shouldSend' := v ]}" := (set_raft_data_shouldSend  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'shouldSend' := v ]}" := (set_raft_data_shouldSend  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'votesReceived' := v ]}" := (set_raft_data_votesReceived  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'votesReceived' := v ]}" := (set_raft_data_votesReceived  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'type' := v ]}" := (set_raft_data_type  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'type' := v ]}" := (set_raft_data_type  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'clientCache' := v ]}" := (set_raft_data_clientCache  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'clientCache' := v ]}" := (set_raft_data_clientCache  _ _ _ _ _ _ _ _ a v).
 
-Notation "{[ a 'with' 'electoralVictories' := v ]}" := (set_raft_data_electoralVictories  _ _ _ _ _ _ _ a v).
+Notation "{[ a 'with' 'electoralVictories' := v ]}" := (set_raft_data_electoralVictories  _ _ _ _ _ _ _ _ a v).
 
 
-Arguments set_raft_data_currentTerm  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_currentTerm  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_votedFor  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_votedFor  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_leaderId  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_leaderId  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_log  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_log  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_commitIndex  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_commitIndex  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_lastApplied  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_lastApplied  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_stateMachine  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_stateMachine  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_nextIndex  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_nextIndex  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_matchIndex  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_matchIndex  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_shouldSend  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_shouldSend  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_votesReceived  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_votesReceived  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_type  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_type  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_clientCache  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_clientCache  _ _ _ _ _ _ _ _ _ _/.
 
-Arguments set_raft_data_electoralVictories  _ _ _ _ _ _ _ _ _/.
+Arguments set_raft_data_electoralVictories  _ _ _ _ _ _ _ _ _ _/.

--- a/raft/RaftState.v.rec
+++ b/raft/RaftState.v.rec
@@ -9,6 +9,7 @@ Section RaftState.
   Variable logIndex : Type.
   Variable serverType : Type.
   Variable stateMachineData : Type.
+  Variable clientId : Type.
   Variable output : Type.
 
   Record raft_data :=
@@ -31,7 +32,7 @@ Section RaftState.
         (* whoami *)
         type : serverType;
         (* client request state *)
-        clientCache : list (nat * (nat * output));
+        clientCache : list (clientId * (nat * output));
         (* ghost variables *)
         electoralVictories : list (term * list name * list entry)
       }.

--- a/raft/RefinementSpecLemmas.v
+++ b/raft/RefinementSpecLemmas.v
@@ -215,7 +215,7 @@ Section SpecLemmas.
   Lemma update_elections_data_request_vote_reply_votesWithLog :
   forall  (h : name)
     (st : electionsData *
-          RaftState.raft_data term name entry logIndex serverType data output)
+          RaftState.raft_data term name entry logIndex serverType data clientId output)
     (src : name) (t : nat) (r : bool),
     votesWithLog (update_elections_data_requestVoteReply h src t r st) =
     votesWithLog (fst st).
@@ -576,7 +576,7 @@ Section SpecLemmas.
   Lemma update_elections_data_request_vote_votesWithLog_old :
     forall (h : name)
       (st : electionsData *
-            RaftState.raft_data term name entry logIndex serverType data output)
+            RaftState.raft_data term name entry logIndex serverType data clientId output)
       (t : nat) (src : fin N) (lli llt : nat)
       (t' : term) (h' : name) (l' : list entry),
       In (t', h', l') (votesWithLog (fst st)) ->

--- a/raft/SpecLemmas.v
+++ b/raft/SpecLemmas.v
@@ -1317,7 +1317,7 @@ Section SpecLemmas.
   Lemma handleRequestVote_reply_true':
   forall (h : name) 
     (h' : fin N)
-    (st : RaftState.raft_data term name entry logIndex serverType data output)
+    (st : RaftState.raft_data term name entry logIndex serverType data clientId output)
     (t lli llt : nat) (st' : raft_data) (t' : term),
     handleRequestVote h st t h' lli llt = (st', RequestVoteReply t' true) ->
     t' = t /\ currentTerm st' = t.
@@ -1327,6 +1327,5 @@ Section SpecLemmas.
     repeat break_match; find_inversion; simpl in *; auto; try congruence;
     do_bool; try omega; eauto using le_antisym.
   Qed.
-
   
 End SpecLemmas.

--- a/raft/TraceUtil.v
+++ b/raft/TraceUtil.v
@@ -5,42 +5,42 @@ Section TraceUtil.
   Context {one_node_params : OneNodeParams orig_base_params}.
   Context {raft_params : RaftParams orig_base_params}.
 
-
-  Definition has_key (c : nat) (i : nat) (e : entry) :=
+  Definition has_key (c : clientId) (i : nat) (e : entry) :=
     match e with
-      | mkEntry _ c' i' _ _ _ => andb (beq_nat c c') (beq_nat i i')
+      | mkEntry _ c' i' _ _ _ => andb (if clientId_eq_dec c c' then true else false) (beq_nat i i')
     end.
 
-  Definition key_in_output_list (client id : nat) (os : list raft_output) :=
+  Definition key_in_output_list (client : clientId) (id : nat) (os : list raft_output) :=
     exists o,
       In (ClientResponse client id o) os.
 
-  Definition is_client_response_with_key (client id : nat) (out : raft_output) : bool :=
+  Definition is_client_response_with_key (client : clientId) (id : nat) (out : raft_output) : bool :=
     match out with
-      | ClientResponse c i _ => andb (beq_nat client c) (beq_nat id i)
+      | ClientResponse c i _ => andb (if clientId_eq_dec client c then true else false) (beq_nat id i)
       | NotLeader _ _ => false
     end.
 
-  Definition key_in_output_list_dec (client id : nat) (os : list raft_output) :
+  Definition key_in_output_list_dec (client : clientId) (id : nat) (os : list raft_output) :
     {key_in_output_list client id os} + {~ key_in_output_list client id os}.
   Proof using. 
     unfold key_in_output_list.
     destruct (find (is_client_response_with_key client id) os) eqn:?.
     - find_apply_lem_hyp find_some. break_and.
       unfold is_client_response_with_key in *. break_match; try discriminate.
-      subst. do_bool. break_and. do_bool. subst. left. eauto.
+      subst. do_bool. break_and. break_if; try discriminate. do_bool. subst. left. eauto.
     - right. intro. break_exists.
       eapply find_none in H; eauto. unfold is_client_response_with_key in *.
-      find_apply_lem_hyp Bool.andb_false_elim. intuition; do_bool; congruence.
+      find_apply_lem_hyp Bool.andb_false_elim.
+      intuition; try break_if; do_bool; congruence.
   Qed.
 
-  Definition key_in_output_trace (client id : nat)
+  Definition key_in_output_trace (client : clientId) (id : nat)
              (tr : list (name * (raft_input + list raft_output))) : Prop :=
     exists os h,
       In (h, inr os) tr /\
       key_in_output_list client id os.
 
-  Definition key_in_output_trace_dec (client id : nat) :
+  Definition key_in_output_trace_dec (client : clientId) (id : nat) :
     forall tr : list (name * (raft_input + list raft_output)),
       {key_in_output_trace client id tr} + {~ key_in_output_trace client id tr}.
   Proof using. 
@@ -57,7 +57,7 @@ Section TraceUtil.
       repeat break_match; try discriminate.
       find_apply_lem_hyp find_some. break_and.
       unfold is_client_response_with_key, key_in_output_list in *.
-      break_match; try discriminate. do_bool. break_and. do_bool. subst.
+      break_match; try discriminate. do_bool. break_and. do_bool. break_if; try discriminate. subst.
       left. exists l, (fst p).
       find_reverse_rewrite. rewrite <- surjective_pairing.
       intuition eauto.
@@ -67,21 +67,21 @@ Section TraceUtil.
       unfold key_in_output_list in *. break_exists.
       find_eapply_lem_hyp find_none; eauto.
       simpl in *. find_apply_lem_hyp Bool.andb_false_elim.
-      intuition (do_bool; congruence).
+      intuition; try break_if; (do_bool; congruence).
   Qed.
 
 
-  Definition in_output_list (client id : nat) (o : output) (os : list raft_output) :=
+  Definition in_output_list (client : clientId) (id : nat) (o : output) (os : list raft_output) :=
     In (ClientResponse client id o) os.
 
-  Definition is_client_response (client id : nat) (o : output) (out : raft_output) : bool :=
+  Definition is_client_response (client : clientId) (id : nat) (o : output) (out : raft_output) : bool :=
     match out with
-      | ClientResponse c i o' => andb (andb (beq_nat client c) (beq_nat id i))
+      | ClientResponse c i o' => andb (andb (if clientId_eq_dec client c then true else false) (beq_nat id i))
                                      (if output_eq_dec o o' then true else false)
       | NotLeader _ _ => false
     end.
 
-  Definition in_output_list_dec (client id : nat) (o : output) (os : list raft_output) :
+  Definition in_output_list_dec (client : clientId) (id : nat) (o : output) (os : list raft_output) :
     {in_output_list client id o os} + {~ in_output_list client id o os}.
   Proof using raft_params. 
     unfold in_output_list.
@@ -89,35 +89,36 @@ Section TraceUtil.
     - find_apply_lem_hyp find_some. break_and.
       unfold is_client_response in *. break_match; try discriminate.
       subst. do_bool. break_and. break_if; try congruence.
+      break_if; try discriminate.
       repeat (do_bool; intuition). subst. intuition.
     - right. intro. break_exists.
       eapply find_none in H; eauto. unfold is_client_response in *.
-      find_apply_lem_hyp Bool.andb_false_elim. repeat (do_bool; intuition); try congruence.
-      break_if; congruence.
+      find_apply_lem_hyp Bool.andb_false_elim.
+      repeat (do_bool; intuition); try break_if; try congruence.
   Qed.
 
-  Definition in_output_trace (client id : nat) (o : output)
+  Definition in_output_trace (client : clientId) (id : nat) (o : output)
              (tr : list (name * (raft_input + list raft_output))) : Prop :=
     exists os h,
       In (h, inr os) tr /\
       in_output_list client id o os.
   
-  Definition in_input_trace (client id : nat) (i : input)
+  Definition in_input_trace (client : clientId) (id : nat) (i : input)
              (tr : list (name * (raft_input + list raft_output))) : Prop :=
       exists h,
         In (h, inl (ClientRequest client id i)) tr.
   
-  Definition is_output_with_key (client id : nat)
+  Definition is_output_with_key (client : clientId) (id : nat)
              (trace_entry : (name * (raft_input + list raft_output))) :=
     match trace_entry with
       | (_, inr os) => if key_in_output_list_dec client id os then true else false
       | _ => false
     end.
 
-  Definition is_input_with_key (client id: nat)
+  Definition is_input_with_key (client : clientId) (id: nat)
              (trace_entry : (name * (raft_input + list raft_output))) :=
     match trace_entry with
-      | (_, inl (ClientRequest c i _)) => andb (beq_nat client c) (beq_nat id i)
+      | (_, inl (ClientRequest c i _)) => andb (if clientId_eq_dec client c then true else false) (beq_nat id i)
       | _ => false
     end.
 End TraceUtil.

--- a/systems/VarDRaft.v
+++ b/systems/VarDRaft.v
@@ -8,7 +8,9 @@ Section VarDRaft.
     {
       N := n;
       input_eq_dec := input_eq_dec;
-      output_eq_dec := output_eq_dec
+      output_eq_dec := output_eq_dec;
+      clientId := nat;
+      clientId_eq_dec := eq_nat_dec
     }.
 
   Definition vard_raft_base_params := base_params.


### PR DESCRIPTION
This PR makes it possible to use UUIDs (e.g., as `string` or `positive`) instead of ints as client identifiers. Also makes it clear that the only salient property about client ids are their decidable equality.