### PR TITLE
switch to strings for client ids and generate UUIDs in clients

### DIFF
--- a/extraction/vard-log/bench/vard.py
+++ b/extraction/vard-log/bench/vard.py
@@ -1,6 +1,6 @@
 import socket
 import re
-from random import randint
+from uuid import uuid4
 from select import select
 from struct import pack, unpack
 
@@ -36,7 +36,7 @@ class Client(object):
     response_re = re.compile(r'Response\W+([0-9]+)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)')
 
     def __init__(self, host, port, sock=None):
-        self.client_id = randint(0, 2**31 - 1)
+        self.client_id = uuid4().hex
         self.request_id = 0
         if sock is None:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -46,11 +46,11 @@ class Client(object):
         self.send_client_id()
 
     def send_client_id(self):
-        n = self.sock.send(pack("<I", 4))
+        n = self.sock.send(pack("<I", len(self.client_id)))
         if n < 4:
             raise SendError
         else:
-            self.sock.send(pack("<I", self.client_id))
+            self.sock.send(self.client_id)
 
     def reconnect(self, host, port, sock=None):
         self.sock.shutdown(1)

--- a/extraction/vard-log/ml/VarDLogArrangement.ml
+++ b/extraction/vard-log/ml/VarDLogArrangement.ml
@@ -43,7 +43,7 @@ module VarDArrangement (P : VarDParams) = struct
   type input = VarDRaftLog.raft_input
   type output = VarDRaftLog.raft_output
   type msg = VarDRaftLog.msg0
-  type client_id = int
+  type client_id = string
   type res = ((file_name DiskOpShim.disk_op list * output list) * state) * ((name * msg) list)
   type disk = log_files -> in_channel option
   let system_name = "VarDLog"
@@ -87,7 +87,7 @@ module VarDArrangement (P : VarDParams) = struct
   let debug_timeout (s : state) = ()
   let debug_input s inp = ()
   let deserialize_client_id = VarDLogSerialization.deserializeClientId
-  let string_of_client_id = string_of_int
+  let string_of_client_id s = s
   let string_of_file_name = fun f -> match f with
                                      | Count -> "count"
                                      | Snapshot -> "snapshot"

--- a/extraction/vard-log/ml/VarDLogSerialization.ml
+++ b/extraction/vard-log/ml/VarDLogSerialization.ml
@@ -7,10 +7,10 @@ open Util
 let outputToString out =
   match Obj.magic out with
   | NotLeader (client_id, request_id) ->
-    (Obj.magic client_id, sprintf "NotLeader %s" (string_of_int request_id))
+    (string_of_char_list (Obj.magic client_id), sprintf "NotLeader %s" (string_of_int request_id))
   | ClientResponse (client_id, request_id, o) ->
      let Response (k, value, old) = (Obj.magic o) in
-     (Obj.magic client_id,
+     (string_of_char_list (Obj.magic client_id),
       match (value, old) with
       | Some v, Some o ->
          sprintf "Response %s %s %s %s"
@@ -58,8 +58,14 @@ let deserializeInp buf =
 let deserializeInput inp client_id =
   match deserializeInp inp with
   | Some (request_id, input) ->
-    Some (ClientRequest (Obj.magic client_id, request_id, Obj.magic input))
+    Some (ClientRequest (Obj.magic (char_list_of_string client_id), request_id, Obj.magic input))
   | None -> None
 
 let deserializeClientId b =
-  if Bytes.length b = 4 then Some (int_of_raw_bytes b) else None
+  let s = Bytes.to_string b in
+  (*let r = regexp "^[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-4[0-9a-f][0-9a-f][0-9a-f]-[89ab][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]$" in*)
+  let r = regexp "^[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]4[0-9a-f][0-9a-f][0-9a-f][89ab][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]$" in
+  if string_match r s 0 then
+    Some s
+  else
+    None

--- a/extraction/vard-serialized-log/bench/vard.py
+++ b/extraction/vard-serialized-log/bench/vard.py
@@ -1,6 +1,6 @@
 import socket
 import re
-from random import randint
+from uuid import uuid4
 from select import select
 from struct import pack, unpack
 
@@ -36,7 +36,7 @@ class Client(object):
     response_re = re.compile(r'Response\W+([0-9]+)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)')
 
     def __init__(self, host, port, sock=None):
-        self.client_id = randint(0, 2**31 - 1)
+        self.client_id = uuid4().hex
         self.request_id = 0
         if sock is None:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -46,11 +46,11 @@ class Client(object):
         self.send_client_id()
 
     def send_client_id(self):
-        n = self.sock.send(pack("<I", 4))
+        n = self.sock.send(pack("<I", len(self.client_id)))
         if n < 4:
             raise SendError
         else:
-            self.sock.send(pack("<I", self.client_id))
+            self.sock.send(self.client_id)
 
     def reconnect(self, host, port, sock=None):
         self.sock.shutdown(1)

--- a/extraction/vard-serialized-log/ml/VarDSerializedLogArrangement.ml
+++ b/extraction/vard-serialized-log/ml/VarDSerializedLogArrangement.ml
@@ -43,7 +43,7 @@ module VarDArrangement (P : VarDParams) = struct
   type input = VarDRaftSerializedLog.raft_input
   type output = VarDRaftSerializedLog.raft_output
   type msg = Serializer_primitives.wire
-  type client_id = int
+  type client_id = string
   type res = ((file_name DiskOpShim.disk_op list * output list) * state) * ((name * msg) list)
   type disk = log_files -> in_channel option
   let system_name = "VarDSerializedLog"
@@ -89,7 +89,7 @@ module VarDArrangement (P : VarDParams) = struct
   let debug_timeout (s : state) = ()
   let debug_input s inp = ()
   let deserialize_client_id = VarDSerializedLogSerialization.deserializeClientId
-  let string_of_client_id = string_of_int
+  let string_of_client_id s = s
   let string_of_file_name = fun f -> match f with
                                      | Count -> "count"
                                      | Snapshot -> "snapshot"

--- a/extraction/vard-serialized-log/ml/VarDSerializedLogSerialization.ml
+++ b/extraction/vard-serialized-log/ml/VarDSerializedLogSerialization.ml
@@ -7,10 +7,10 @@ open Util
 let outputToString out =
   match Obj.magic out with
   | NotLeader (client_id, request_id) ->
-    (Obj.magic client_id, sprintf "NotLeader %s" (string_of_int request_id))
+    (string_of_char_list (Obj.magic client_id), sprintf "NotLeader %s" (string_of_int request_id))
   | ClientResponse (client_id, request_id, o) ->
      let Response (k, value, old) = (Obj.magic o) in
-     (Obj.magic client_id,
+     (string_of_char_list (Obj.magic client_id),
       match (value, old) with
       | Some v, Some o ->
          sprintf "Response %s %s %s %s"
@@ -58,8 +58,14 @@ let deserializeInp buf =
 let deserializeInput inp client_id =
   match deserializeInp inp with
   | Some (request_id, input) ->
-    Some (ClientRequest (Obj.magic client_id, request_id, Obj.magic input))
+    Some (ClientRequest (Obj.magic (char_list_of_string client_id), request_id, Obj.magic input))
   | None -> None
 
 let deserializeClientId b =
-  if Bytes.length b = 4 then Some (int_of_raw_bytes b) else None
+  let s = Bytes.to_string b in
+  (*let r = regexp "^[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-4[0-9a-f][0-9a-f][0-9a-f]-[89ab][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]$" in*)
+  let r = regexp "^[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]4[0-9a-f][0-9a-f][0-9a-f][89ab][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]$" in
+  if string_match r s 0 then
+    Some s
+  else
+    None

--- a/extraction/vard-serialized/bench/vard.py
+++ b/extraction/vard-serialized/bench/vard.py
@@ -1,6 +1,6 @@
 import socket
 import re
-from random import randint
+from uuid import uuid4
 from select import select
 from struct import pack, unpack
 
@@ -36,7 +36,7 @@ class Client(object):
     response_re = re.compile(r'Response\W+([0-9]+)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)')
 
     def __init__(self, host, port, sock=None):
-        self.client_id = randint(0, 2**31 - 1)
+        self.client_id = uuid4().hex
         self.request_id = 0
         if sock is None:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -46,11 +46,11 @@ class Client(object):
         self.send_client_id()
 
     def send_client_id(self):
-        n = self.sock.send(pack("<I", 4))
+        n = self.sock.send(pack("<I", len(self.client_id)))
         if n < 4:
             raise SendError
         else:
-            self.sock.send(pack("<I", self.client_id))
+            self.sock.send(self.client_id)
 
     def reconnect(self, host, port, sock=None):
         self.sock.shutdown(1)

--- a/extraction/vard-serialized/ml/VarDSerializedArrangement.ml
+++ b/extraction/vard-serialized/ml/VarDSerializedArrangement.ml
@@ -40,7 +40,7 @@ module VarDArrangement (P : VarDParams) = struct
   type output = VarDRaftSerialized.raft_output
   type msg = Serializer_primitives.wire
   type res = (output list * state) * ((name * msg) list)
-  type client_id = int
+  type client_id = string
   let system_name = "VarDSerialized"
   let init = Obj.magic ((transformed_multi_params P.num_nodes).init_handlers)
   let reboot = Obj.magic (transformed_failure_params P.num_nodes)
@@ -85,5 +85,5 @@ module VarDArrangement (P : VarDParams) = struct
   let debug_timeout (s : state) = ()
   let debug_input s inp = ()
   let deserialize_client_id = VarDSerializedSerialization.deserializeClientId 
-  let string_of_client_id = string_of_int
+  let string_of_client_id s = s
 end

--- a/extraction/vard-serialized/ml/VarDSerializedSerialization.ml
+++ b/extraction/vard-serialized/ml/VarDSerializedSerialization.ml
@@ -7,10 +7,10 @@ open Util
 let outputToString out =
   match Obj.magic out with
   | NotLeader (client_id, request_id) ->
-    (Obj.magic client_id, sprintf "NotLeader %s" (string_of_int request_id))
+    (string_of_char_list (Obj.magic client_id), sprintf "NotLeader %s" (string_of_int request_id))
   | ClientResponse (client_id, request_id, o) ->
      let Response (k, value, old) = (Obj.magic o) in
-     (Obj.magic client_id,
+     (string_of_char_list (Obj.magic client_id),
       match (value, old) with
       | Some v, Some o ->
          sprintf "Response %s %s %s %s"
@@ -56,8 +56,14 @@ let deserializeInp buf =
 let deserializeInput inp client_id =
   match deserializeInp inp with
   | Some (request_id, input) ->
-    Some (ClientRequest (Obj.magic client_id, request_id, Obj.magic input))
+    Some (ClientRequest (Obj.magic (char_list_of_string client_id), request_id, Obj.magic input))
   | None -> None
 
 let deserializeClientId b =
-  if Bytes.length b = 4 then Some (int_of_raw_bytes b) else None
+  let s = Bytes.to_string b in
+  (*let r = regexp "^[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-4[0-9a-f][0-9a-f][0-9a-f]-[89ab][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]$" in*)
+  let r = regexp "^[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]4[0-9a-f][0-9a-f][0-9a-f][89ab][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]$" in
+  if string_match r s 0 then
+    Some s
+  else
+    None

--- a/extraction/vard-serialized/test/VarDSerializedSerializationTest.ml
+++ b/extraction/vard-serialized/test/VarDSerializedSerializationTest.ml
@@ -4,14 +4,15 @@ open Util
 
 let tear_down () text_ctxt = ()
 
+
 let test_serialize_output_not_leader text_ctxt =
-  assert_equal (2, Bytes.of_string "NotLeader 15")
-    (VarDSerializedSerialization.serializeOutput (VarDRaftSerialized.NotLeader (Obj.magic 2, 15)))
+  assert_equal ("0aac4d743ccc4473a2e04f4072734722", Bytes.of_string "NotLeader 15")
+    (VarDSerializedSerialization.serializeOutput (VarDRaftSerialized.NotLeader (Obj.magic (char_list_of_string "0aac4d743ccc4473a2e04f4072734722"), 15)))
 
 let test_serialize_output_client_response test_ctxt =
   let o = VarDRaftSerialized.Response (char_list_of_string "awesome", None, None) in
-  assert_equal (3, Bytes.of_string "Response 34 awesome - -")
-    (VarDSerializedSerialization.serializeOutput (VarDRaftSerialized.ClientResponse (Obj.magic 3, 34, (Obj.magic o))))
+  assert_equal ("0f5f33f091094d5db68a72e9f4cf9b14", Bytes.of_string "Response 34 awesome - -")
+    (VarDSerializedSerialization.serializeOutput (VarDRaftSerialized.ClientResponse (Obj.magic (char_list_of_string "0f5f33f091094d5db68a72e9f4cf9b14"), 34, (Obj.magic o))))
   
 let test_list =
   [

--- a/extraction/vard/bench/vard.py
+++ b/extraction/vard/bench/vard.py
@@ -1,6 +1,6 @@
 import socket
 import re
-from random import randint
+from uuid import uuid4
 from select import select
 from struct import pack, unpack
 
@@ -36,7 +36,7 @@ class Client(object):
     response_re = re.compile(r'Response\W+([0-9]+)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)\W+([/A-Za-z0-9]+|-)')
 
     def __init__(self, host, port, sock=None):
-        self.client_id = randint(0, 2**31 - 1)
+        self.client_id = uuid4().hex
         self.request_id = 0
         if sock is None:
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -46,11 +46,11 @@ class Client(object):
         self.send_client_id()
 
     def send_client_id(self):
-        n = self.sock.send(pack("<I", 4))
+        n = self.sock.send(pack("<I", len(self.client_id)))
         if n < 4:
             raise SendError
         else:
-            self.sock.send(pack("<I", self.client_id))
+            self.sock.send(self.client_id)
 
     def reconnect(self, host, port, sock=None):
         self.sock.shutdown(1)

--- a/extraction/vard/ml/VarDArrangement.ml
+++ b/extraction/vard/ml/VarDArrangement.ml
@@ -40,7 +40,7 @@ module VarDArrangement (P : VarDParams) = struct
   type output = VarDRaft.raft_output
   type msg = VarDRaft.msg
   type res = (VarDRaft.raft_output list * raft_data0) * ((VarDRaft.name * VarDRaft.msg) list)
-  type client_id = int
+  type client_id = string
   let system_name = "VarD"
   let init = Obj.magic ((vard_raft_multi_params P.num_nodes).init_handlers)
   let reboot = Obj.magic (vard_raft_failure_params P.num_nodes)
@@ -81,5 +81,5 @@ module VarDArrangement (P : VarDParams) = struct
   let debug_timeout (s : state) = ()
   let debug_input s inp = ()
   let deserialize_client_id = VarDSerialization.deserializeClientId
-  let string_of_client_id = string_of_int
+  let string_of_client_id s = s
 end

--- a/extraction/vard/ml/VarDSerialization.ml
+++ b/extraction/vard/ml/VarDSerialization.ml
@@ -8,10 +8,10 @@ let serializeOutput out =
   let (c, os) =
     match Obj.magic out with
     | NotLeader (client_id, request_id) ->
-       (Obj.magic client_id, sprintf "NotLeader %s" (string_of_int request_id))
+       (string_of_char_list (Obj.magic client_id), sprintf "NotLeader %s" (string_of_int request_id))
     | ClientResponse (client_id, request_id, o) ->
        let Response (k, value, old) = Obj.magic o in
-       (Obj.magic client_id,
+       (string_of_char_list (Obj.magic client_id),
         match value, old with
         | Some v, Some o ->
            sprintf "Response %s %s %s %s"
@@ -55,7 +55,7 @@ let deserializeInp i =
 let deserializeInput inp client_id =
   match deserializeInp inp with
   | Some (request_id, input) ->
-    Some (ClientRequest (Obj.magic client_id, request_id, Obj.magic input))
+    Some (ClientRequest (Obj.magic (char_list_of_string client_id), request_id, Obj.magic input))
   | None -> None
 
 let deserializeMsg (b : bytes) : VarDRaft.msg = Marshal.from_bytes b 0
@@ -63,4 +63,10 @@ let deserializeMsg (b : bytes) : VarDRaft.msg = Marshal.from_bytes b 0
 let serializeMsg (msg : VarDRaft.msg) : bytes = Marshal.to_bytes msg []
 
 let deserializeClientId b =
-  if Bytes.length b = 4 then Some (int_of_raw_bytes b) else None
+  let s = Bytes.to_string b in
+  (*let r = regexp "^[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f]-4[0-9a-f][0-9a-f][0-9a-f]-[89ab][0-9a-f][0-9a-f][0-9a-f]-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]$" in*)
+  let r = regexp "^[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]4[0-9a-f][0-9a-f][0-9a-f][89ab][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]$" in
+  if string_match r s 0 then
+    Some s
+  else
+    None

--- a/extraction/vard/test/VarDSerializationTest.ml
+++ b/extraction/vard/test/VarDSerializationTest.ml
@@ -5,13 +5,13 @@ open Util
 let tear_down () text_ctxt = ()
 
 let test_serialize_output_not_leader text_ctxt =
-  assert_equal (2, Bytes.of_string "NotLeader 15")
-    (VarDSerialization.serializeOutput (VarDRaft.NotLeader (Obj.magic 2, 15)))
+  assert_equal ("0aac4d743ccc4473a2e04f4072734722", Bytes.of_string "NotLeader 15")
+    (VarDSerialization.serializeOutput (VarDRaft.NotLeader (Obj.magic (char_list_of_string "0aac4d743ccc4473a2e04f4072734722"), 15)))
 
 let test_serialize_output_client_response test_ctxt =
   let o = VarDRaft.Response (char_list_of_string "awesome", None, None) in
-  assert_equal (3, Bytes.of_string "Response 34 awesome - -")
-    (VarDSerialization.serializeOutput (VarDRaft.ClientResponse (Obj.magic 3, 34, (Obj.magic o))))
+  assert_equal ("0f5f33f091094d5db68a72e9f4cf9b14", Bytes.of_string "Response 34 awesome - -")
+    (VarDSerialization.serializeOutput (VarDRaft.ClientResponse (Obj.magic (char_list_of_string "0f5f33f091094d5db68a72e9f4cf9b14"), 34, (Obj.magic o))))
 
 let test_list =
   [

--- a/systems/VarDRaft.v
+++ b/systems/VarDRaft.v
@@ -1,5 +1,6 @@
 Require Import VerdiRaft.Raft.
 Require Import Verdi.VarD.
+Require Import String.
 
 Section VarDRaft.
   Variable n : nat.
@@ -9,8 +10,8 @@ Section VarDRaft.
       N := n;
       input_eq_dec := input_eq_dec;
       output_eq_dec := output_eq_dec;
-      clientId := nat;
-      clientId_eq_dec := eq_nat_dec
+      clientId := string;
+      clientId_eq_dec := string_dec
     }.
 
   Definition vard_raft_base_params := base_params.

--- a/systems/VarDRaftSerializers.v
+++ b/systems/VarDRaftSerializers.v
@@ -302,10 +302,8 @@ Section Serializers.
       repeat (cheerios_crush; simpl).
     rewrite nat_serialize_deserialize_id.
     repeat (cheerios_crush; simpl).
-    rewrite nat_serialize_deserialize_id.
-    repeat (cheerios_crush; simpl).
-    rewrite input_serialize_deserialize_id.
-    cheerios_crush.
+    unfold serialize_input, deserialize_input.
+    destruct i; repeat (cheerios_crush; simpl).
   Qed.
 
   Global Instance raft_input_Serializer : Serializer raft_input :=


### PR DESCRIPTION
This makes interoperability with other clients than our Python client much easier to implement (UUID format is standardized and platform-independent).