### PR TITLE
use Program Instance to avoid the soon-obsolete instance refinement mode

### DIFF
--- a/raft-proofs/AppliedImpliesInputProof.v
+++ b/raft-proofs/AppliedImpliesInputProof.v
@@ -395,20 +395,27 @@ Section AppliedImpliesInputProof.
           right. intro. repeat (break_exists; intuition); eauto 10.
     Defined.
 
-    Instance ITR : InverseTraceRelation step_failure :=
-      { init := step_failure_init;
+    Program Instance ITR : InverseTraceRelation step_failure :=
+      {
+        init := step_failure_init;
         R := fun s => applied_implies_input_state client id i (snd s);
         T := in_input_trace client id i
       }.
-    - intros. apply applied_implies_input_state_dec.
-    - intros.
+    Next Obligation.
+      apply applied_implies_input_state_dec.
+    Defined.
+    Next Obligation.
       unfold in_input_trace in *. break_exists_exists.
       intuition.
-    - unfold applied_implies_input_state. intro. break_exists. break_and.
+    Defined.
+    Next Obligation.
+      unfold applied_implies_input_state. intro. break_exists. break_and.
       intuition; break_exists; intuition.
-    - intros. simpl in *.
+    Defined.
+    Next Obligation.
+      simpl in *.
       apply in_input_trace_or_app. right.
-      destruct s, s'. simpl in *.
+      simpl in *.
       eapply applied_implies_input_in_input_trace; eauto.
       eapply step_failure_star_raft_intermediate_reachable; eauto.
     Defined.
@@ -429,7 +436,7 @@ Section AppliedImpliesInputProof.
   Qed.
 
   Instance aiii : applied_implies_input_interface.
-  Proof.
+  Proof using.
     split.
     exact applied_implies_input.
   Qed.

--- a/raft-proofs/CausalOrderPreservedProof.v
+++ b/raft-proofs/CausalOrderPreservedProof.v
@@ -98,39 +98,37 @@ Section CausalOrderPreserved.
       + simpl in *. intuition.
   Qed.
   
-  Instance TR : TraceRelation step_failure :=
+  Program Instance TR : TraceRelation step_failure :=
     {
       init := step_failure_init;
       T := output_before_input client id client' id';
       R := fun s => entries_ordered client id client' id' (snd s)
     }.
-  Proof.
-    - intros.
-      unfold output_before_input.
-      eapply before_func_dec.
-    - intros.
-      destruct s as (failed, net).
-      destruct s' as (failed', net'). simpl in *.
-      unfold entries_ordered in *.
-      find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
-      find_eapply_lem_hyp applied_entries_monotonic'; eauto.
-      break_exists; repeat find_rewrite.
-      eauto using before_func_app.
-    - intuition.
-    - intros.
-      destruct s as (failed, net).
-      destruct s' as (failed', net'). simpl in *.
-      find_copy_eapply_lem_hyp output_before_input_not_key_in_input_trace; eauto.
-      find_copy_apply_lem_hyp output_before_input_key_in_output_trace.
-      find_eapply_lem_hyp output_implies_applied;
-        [|eapply refl_trans_n1_1n_trace; econstructor; eauto using refl_trans_1n_n1_trace].
-      eapply in_applied_entries_entries_ordered; auto.
-      intuition.
-      find_false.
-      find_apply_lem_hyp in_applied_entries_applied_implies_input_state.
-      break_exists. intuition.
-      eexists. eapply applied_implies_input; eauto.
-      eapply refl_trans_n1_1n_trace; econstructor; eauto using refl_trans_1n_n1_trace.
+  Next Obligation.
+    unfold output_before_input.
+    eapply before_func_dec.
+  Defined.
+  Next Obligation.
+    simpl in *.
+    unfold entries_ordered in *.
+    find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
+    find_eapply_lem_hyp applied_entries_monotonic'; eauto.
+    break_exists; repeat find_rewrite.
+    eauto using before_func_app.
+  Defined.
+  Next Obligation.
+    simpl in *.
+    find_copy_eapply_lem_hyp output_before_input_not_key_in_input_trace; eauto.
+    find_copy_apply_lem_hyp output_before_input_key_in_output_trace.
+    find_eapply_lem_hyp output_implies_applied;
+      [|eapply refl_trans_n1_1n_trace; econstructor; eauto using refl_trans_1n_n1_trace].
+    eapply in_applied_entries_entries_ordered; auto.
+    intuition.
+    find_false.
+    find_apply_lem_hyp in_applied_entries_applied_implies_input_state.
+    break_exists. intuition.
+    eexists. eapply applied_implies_input; eauto.
+    eapply refl_trans_n1_1n_trace; econstructor; eauto using refl_trans_1n_n1_trace.
   Defined.
 
   Theorem causal_order_preserved :

--- a/raft-proofs/InputBeforeOutputProof.v
+++ b/raft-proofs/InputBeforeOutputProof.v
@@ -635,38 +635,40 @@ Section InputBeforeOutput.
         eauto.
   Qed.
 
-  Instance TR : InverseTraceRelation step_failure :=
+  Program Instance TR : InverseTraceRelation step_failure :=
     {
       init := step_failure_init;
       T := input_before_output client id;
       R := fun s => in_applied_entries client id (snd s) 
     }.
-  Proof.
-    - intros.
-      destruct (client_id_in (applied_entries (nwState (snd s)))) eqn:?;
-      eauto using client_id_in_true_in_applied_entries, client_id_in_false_not_in_applied_entries.
-    - intros.
-      unfold input_before_output in *.
-      eauto using before_func_app.
-    - intuition. simpl in *.
-      unfold in_applied_entries, applied_entries in *. simpl in *.
-      break_match; simpl in *; break_exists; intuition.
-    - intros.
-      destruct s as (failed, net).
-      destruct s' as (failed', net'). simpl in *.
-      find_eapply_lem_hyp in_applied_entries_step_applied_implies_input_state; eauto.
-      break_or_hyp.
-      + break_exists. intuition.
-        find_eapply_lem_hyp applied_implies_input; eauto.
-        apply before_func_app.
-        destruct (key_in_output_trace_dec client id tr);
-          [find_eapply_lem_hyp output_implies_applied; eauto; intuition|].
-        fold (input_before_output client id tr).
-        subst. eauto using in_input_not_in_output_input_before_output.
-      + destruct (key_in_output_trace_dec client id tr);
+  Next Obligation.
+    destruct (client_id_in (applied_entries (nwState n))) eqn:?;
+    eauto using client_id_in_true_in_applied_entries, client_id_in_false_not_in_applied_entries.
+  Defined.
+  Next Obligation.
+    unfold input_before_output in *.
+    eauto using before_func_app.
+  Defined.
+  Next Obligation.
+    intuition. simpl in *.
+    unfold in_applied_entries, applied_entries in *. simpl in *.
+    break_match; simpl in *; break_exists; intuition.
+  Defined.
+  Next Obligation.
+    simpl in *.
+    find_eapply_lem_hyp in_applied_entries_step_applied_implies_input_state; eauto.
+    break_or_hyp.
+    - break_exists. intuition.
+      find_eapply_lem_hyp applied_implies_input; eauto.
+      apply before_func_app.
+      destruct (key_in_output_trace_dec client id tr);
         [find_eapply_lem_hyp output_implies_applied; eauto; intuition|].
-        break_exists. subst.
-        eauto using input_before_output_not_key_in_output_trace_snoc_key.
+      fold (input_before_output client id tr).
+      subst. eauto using in_input_not_in_output_input_before_output.
+    - destruct (key_in_output_trace_dec client id tr);
+      [find_eapply_lem_hyp output_implies_applied; eauto; intuition|].
+      break_exists. subst.
+      eauto using input_before_output_not_key_in_output_trace_snoc_key.
   Defined.
 
   Theorem output_implies_input_before_output :

--- a/raft-proofs/OutputCorrectProof.v
+++ b/raft-proofs/OutputCorrectProof.v
@@ -860,7 +860,7 @@ Section OutputCorrect.
     - exfalso. eauto using in_output_trace_not_nil.
   Qed.
 
-  Instance TR : TraceRelation step_failure :=
+  Program Instance TR : TraceRelation step_failure :=
     {
       init := step_failure_init;
       T := in_output_trace client id out ;
@@ -868,25 +868,26 @@ Section OutputCorrect.
       R := fun s => let (_, net) := s in
                     output_correct client id out (applied_entries (nwState net))
     }.
-  Proof.
-    - intros. repeat break_let. subst.
-      find_eapply_lem_hyp applied_entries_monotonic';
-        eauto using step_failure_star_raft_intermediate_reachable.
-      unfold output_correct in *.
-      break_exists.
-      repeat find_rewrite.
-      match goal with
-          | [ |- context [ deduplicate_log (?l ++ ?l') ] ] =>
-            pose proof deduplicate_log_app l l'; break_exists; find_rewrite
-      end.
-      repeat eexists; intuition eauto; repeat find_rewrite; auto.
-      rewrite app_ass. simpl. repeat f_equal.
-  - unfold in_output_trace in *. intuition.
+  Next Obligation.
+    repeat break_let. subst.
+    find_eapply_lem_hyp applied_entries_monotonic';
+      eauto using step_failure_star_raft_intermediate_reachable.
+    unfold output_correct in *.
+    break_exists.
+    repeat find_rewrite.
+    match goal with
+    | [ |- context [ deduplicate_log (?l ++ ?l') ] ] =>
+      pose proof deduplicate_log_app l l'; break_exists; find_rewrite
+    end.
+    repeat eexists; intuition eauto; repeat find_rewrite; auto.
+    rewrite app_ass. simpl. repeat f_equal.
+  Defined.
+  Next Obligation.
+    unfold in_output_trace in *. intuition.
     break_exists; intuition.
-  - intros.
-    break_let. subst.
+  Defined.
+  Next Obligation.
     find_apply_lem_hyp in_output_changed; auto.
-    destruct s.
     eauto using in_output_trace_step_output_correct, step_failure_star_raft_intermediate_reachable.
   Defined.
 
@@ -903,7 +904,7 @@ Section OutputCorrect.
   End inner.
 
   Instance oci : output_correct_interface.
-  Proof.
+  Proof using smci si lmi lacimi aemi.
     split.
     exact output_correct.
   Qed.

--- a/raft-proofs/OutputGreatestIdProof.v
+++ b/raft-proofs/OutputGreatestIdProof.v
@@ -356,31 +356,30 @@ Section OutputGreatestId.
   Section inner.
     Variable client : clientId.
     Variables id id' : nat.
-    Variable id_lt_id' : id < id'.    
+    Variable id_lt_id' : id < id'.
 
-    Instance TR : TraceRelation step_failure :=
+    Program Instance TR : TraceRelation step_failure :=
       {
         init := step_failure_init;
         T := key_in_output_trace client id ;
         T_dec := key_in_output_trace_dec client id ;
         R := fun s => before_func (has_key client id) (has_key client id') (applied_entries (nwState (snd s)))
       }.
-    Proof.
-      - intros.
-        destruct s as (failed, net).
-        destruct s' as (failed', net'). simpl in *.
-        find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
-        find_eapply_lem_hyp applied_entries_monotonic'; eauto.
-        break_exists; repeat find_rewrite.
-        eauto using before_func_app.
-      - unfold key_in_output_trace in *. intuition.
-        break_exists; intuition.
-      - intros.
-        destruct s as [failed net].
-        destruct s' as [failed' net']. simpl in *.
-        find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
-        find_apply_lem_hyp in_output_changed; auto.
-        eauto using output_implies_greatest.
+    Next Obligation.
+      simpl in *.
+      find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
+      find_eapply_lem_hyp applied_entries_monotonic'; eauto.
+      break_exists; repeat find_rewrite.
+      eauto using before_func_app.
+    Defined.
+    Next Obligation.
+      unfold key_in_output_trace in *. intuition.
+      break_exists; intuition.
+    Defined.
+    Next Obligation.
+      find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
+      find_apply_lem_hyp in_output_changed; auto.
+      eauto using output_implies_greatest.
     Defined.
 
   Theorem output_greatest_id :

--- a/raft-proofs/OutputImpliesAppliedProof.v
+++ b/raft-proofs/OutputImpliesAppliedProof.v
@@ -232,24 +232,25 @@ Section OutputImpliesApplied.
       simpl in *. rewrite_update; eauto.
   Qed.
 
-  Instance TR : TraceRelation step_failure :=
+  Program Instance TR : TraceRelation step_failure :=
     {
       init := step_failure_init;
       T := key_in_output_trace client id ;
       T_dec := key_in_output_trace_dec client id ;
       R := fun s => in_applied_entries client id (snd s)
     }.
-  Proof.
-  - intros.
+  Next Obligation.
     unfold in_applied_entries in *.
     break_exists; eexists; intuition eauto.
-    destruct s; destruct s'; eapply applied_entries_monotonic; eauto.
+    eapply applied_entries_monotonic; eauto.
     eauto using refl_trans_1n_n1_trace, step_failure_star_raft_intermediate_reachable.
-  - unfold key_in_output_trace in *. intuition.
+  Defined.
+  Next Obligation.
+    unfold key_in_output_trace in *. intuition.
     break_exists; intuition.
-  - intros.
-    destruct s as [failed net].
-    destruct s' as [failed' net']. simpl in *.
+  Defined.
+  Next Obligation.
+    simpl in *.
     find_apply_lem_hyp step_failure_star_raft_intermediate_reachable.
     find_apply_lem_hyp in_output_changed; auto.
     eauto using output_implies_in_applied_entries.

--- a/raft/Raft.v
+++ b/raft/Raft.v
@@ -501,14 +501,12 @@ Section Raft.
       msg_eq_dec := msg_eq_dec ;
       name_eq_dec := name_eq_dec ;
       nodes := nodes ;
-      init_handlers := init_handlers;
+      all_names_nodes := all_fin_all N ;
+      no_dup_nodes := all_fin_NoDup N ;
+      init_handlers := init_handlers ;
       net_handlers := RaftNetHandler ;
       input_handlers := RaftInputHandler
     }.
-  Proof.
-    - eauto using all_fin_all.
-    - eauto using all_fin_NoDup.
-  Defined.
 
   Instance failure_params : FailureParams _ :=
     {


### PR DESCRIPTION
As per coq/coq#9270.