### PR TITLE
compatibility with Coq PR 11906

### DIFF
--- a/raft/SpecLemmas.v
+++ b/raft/SpecLemmas.v
@@ -29,7 +29,7 @@ Section SpecLemmas.
   Proof using. 
     unfold handleRequestVote.
     intros.
-    repeat break_match; repeat find_inversion; intuition.
+    repeat break_match; repeat find_inversion; intuition idtac.
     - simpl in *. discriminate.
     - unfold advanceCurrentTerm in *.
       break_if; simpl in *; do_bool; intuition.


### PR DESCRIPTION
Coq PR #11906 extends `lia` with support for boolean operators.
This has the consequence that `intuition` is able to perform some
boolean reasoning e.g. true = false -> 0 = 1.
The PR replaces a call to `intuition` by `intuition idtac`.