### PR TITLE
Adapt to coq/coq#13837 ("apply with" does not rename arguments)

### DIFF
--- a/raft-proofs/AllEntriesLogProof.v
+++ b/raft-proofs/AllEntriesLogProof.v
@@ -479,7 +479,7 @@ Ltac all f ls :=
                 all:(try solve [eapply entries_sorted_nw_invariant; eauto]).
                 match goal with
                   | H : eIndex ?e1 = eIndex ?e2, _ : In ?e1 ?ll, _ : In ?e2 ?ll |- _ =>
-                    eapply uniqueIndices_elim_eq with (xs0 := ll) in H
+                    eapply @uniqueIndices_elim_eq with (xs := ll) in H
                 end; eauto using sorted_uniqueIndices.
                 subst. intuition.
           }

--- a/raft-proofs/AppendEntriesLeaderProof.v
+++ b/raft-proofs/AppendEntriesLeaderProof.v
@@ -279,8 +279,8 @@ Section AppendEntriesLeader.
               |- _ ] =>
             match the_net with
             | context [ st' ] =>
-              apply one_leaderLog_per_term_host_invariant
-              with (net0 := the_net) (t := the_t) (ll := the_ll) (ll' := the_ll')
+              apply @one_leaderLog_per_term_host_invariant
+              with (net := the_net) (t := the_t) (ll := the_ll) (ll' := the_ll')
             end
           end; auto; simpl; repeat find_higher_order_rewrite; rewrite_update; simpl; auto.
         }

--- a/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
+++ b/raft-proofs/AppendEntriesRequestReplyCorrespondenceProof.v
@@ -41,7 +41,7 @@ Section AppendEntriesRequestReplyCorrespondence.
       exists (mkN (ps' ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) st').
       subst.
       exists pli,plt,ci,n. simpl in *; intuition.
-      eapply RIR_handleInput with (net0 := net') (inp := Timeout); eauto;
+      eapply @RIR_handleInput with (net := net') (inp := Timeout); eauto;
       simpl; repeat find_rewrite; eauto.
       intros.
       do_in_app. intuition.
@@ -73,7 +73,7 @@ Section AppendEntriesRequestReplyCorrespondence.
       exists (mkN (ps' ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) st').
       subst.
       exists pli,plt,ci,n. simpl in *; intuition.
-      eapply RIR_handleInput with (net0 := net') (inp := ClientRequest client id c); eauto;
+      eapply @RIR_handleInput with (net := net') (inp := ClientRequest client id c); eauto;
       simpl; repeat find_rewrite; eauto.
       intros.
       do_in_app. intuition.
@@ -106,7 +106,7 @@ Section AppendEntriesRequestReplyCorrespondence.
       exists (mkN (ps' ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) st').
       subst.
       exists pli,plt,ci,n. simpl in *; intuition.
-      eapply RIR_doLeader with (net0 := net'); eauto;
+      eapply @RIR_doLeader with (net := net'); eauto;
       simpl; repeat find_rewrite; eauto.
       intros.
       do_in_app. intuition.
@@ -138,7 +138,7 @@ Section AppendEntriesRequestReplyCorrespondence.
       exists (mkN (ps' ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) st').
       subst.
       exists pli,plt,ci,n. simpl in *; intuition.
-      eapply RIR_doGenericServer with (net0 := net'); eauto;
+      eapply @RIR_doGenericServer with (net := net'); eauto;
       simpl; repeat find_rewrite; eauto.
       intros.
       do_in_app. intuition.
@@ -170,7 +170,7 @@ Section AppendEntriesRequestReplyCorrespondence.
     exists (mkN ((nwPackets net) ++ [mkP (pDst p) (pSrc p) (AppendEntries t n pli plt es ci)]) (nwState net')).
     subst.
     exists pli,plt,ci,n. simpl in *; repeat find_rewrite; intuition.
-    eapply RIR_step_failure with (net0 := net''); [|eapply StepFailure_reboot with (h0 := h) (failed := [h])]; eauto;
+    eapply @RIR_step_failure with (net := net''); [|eapply @StepFailure_reboot with (h := h) (failed := [h])]; eauto;
     simpl; repeat find_rewrite; eauto.
     f_equal.
     apply functional_extensionality.
@@ -267,7 +267,7 @@ Section AppendEntriesRequestReplyCorrespondence.
             by (find_rewrite_lem app_ass; rewrite app_comm_cons; auto);
             clear H
       end.
-      eapply RIR_handleMessage with (net0 := net') (p1 := p);
+      eapply @RIR_handleMessage with (net := net') (p := p);
       simpl; repeat find_rewrite; eauto;
       simpl; repeat break_let; eauto; try find_inversion; eauto.
       intros. do_in_app. simpl in *.
@@ -286,8 +286,8 @@ Section AppendEntriesRequestReplyCorrespondence.
       simpl in *. intuition.
       + match goal with
           | _ : raft_intermediate_reachable (mkNetwork ?ps ?st) |- _ =>
-            eapply RIR_handleMessage with (net0 := (mkNetwork ps st)) (p0 := p)
-                                                                      (xs0 := (p :: xs))
+            eapply @RIR_handleMessage with (net := (mkNetwork ps st)) (p := p)
+                                                                      (xs := (p :: xs))
         end; eauto;
         simpl in *; repeat find_rewrite; simpl in *; repeat break_let; eauto;
         repeat find_inversion; eauto.
@@ -328,7 +328,7 @@ Section AppendEntriesRequestReplyCorrespondence.
             by (find_rewrite_lem app_ass; rewrite app_comm_cons; auto);
             clear H
       end.
-      eapply RIR_handleMessage with (net0 := net') (p1 := p);
+      eapply @RIR_handleMessage with (net := net') (p := p);
       simpl; repeat find_rewrite; eauto;
       simpl; repeat break_let; eauto; try find_inversion; eauto.
       intros. do_in_app. simpl in *.
@@ -367,7 +367,7 @@ Section AppendEntriesRequestReplyCorrespondence.
             by (find_rewrite_lem app_ass; rewrite app_comm_cons; auto);
             clear H
       end.
-      eapply RIR_handleMessage with (net0 := net') (p1 := p);
+      eapply @RIR_handleMessage with (net := net') (p := p);
       simpl; repeat find_rewrite; eauto;
       simpl; repeat break_let; eauto; try find_inversion; eauto.
       intros. do_in_app. simpl in *.
@@ -404,7 +404,7 @@ Section AppendEntriesRequestReplyCorrespondence.
           by (find_rewrite_lem app_ass; rewrite app_comm_cons; auto);
           clear H
     end.
-    eapply RIR_handleMessage with (net0 := net') (p1 := p);
+    eapply @RIR_handleMessage with (net := net') (p := p);
       simpl; repeat find_rewrite; eauto;
       simpl; repeat break_let; eauto; try find_inversion; eauto.
     intros. do_in_app. simpl in *.

--- a/raft-proofs/EveryEntryWasCreatedProof.v
+++ b/raft-proofs/EveryEntryWasCreatedProof.v
@@ -68,7 +68,7 @@ Section EveryEntryWasCreated.
     - find_eapply_lem_hyp handleAppendEntries_not_append_entries.
       find_apply_hyp_hyp. intuition.
       + match goal with
-          | _ : In ?p' (_ ++ _) |- _ => eapply in_aer with (p1 := p'); eauto
+          | _ : In ?p' (_ ++ _) |- _ => eapply @in_aer with (p := p'); eauto
         end.
       + subst. simpl in *.
         find_false. unfold mEntries in *.
@@ -98,7 +98,7 @@ Section EveryEntryWasCreated.
     - find_eapply_lem_hyp handleRequestVote_no_append_entries.
       find_apply_hyp_hyp. intuition.
       + match goal with
-          | _ : In ?p' (_ ++ _) |- _ => eapply in_aer with (p1 := p'); eauto
+          | _ : In ?p' (_ ++ _) |- _ => eapply @in_aer with (p := p'); eauto
         end.
       + subst. simpl in *.
         find_false. unfold mEntries in *.
@@ -127,7 +127,7 @@ Section EveryEntryWasCreated.
     - find_eapply_lem_hyp handleAppendEntriesReply_packets.
       find_apply_hyp_hyp. intuition.
       + match goal with
-          | _ : In ?p' (_ ++ _) |- _ => eapply in_aer with (p1 := p'); eauto
+          | _ : In ?p' (_ ++ _) |- _ => eapply @in_aer with (p := p'); eauto
         end.
       + subst. simpl in *. intuition.
     - repeat find_higher_order_rewrite.
@@ -149,7 +149,7 @@ Section EveryEntryWasCreated.
       find_rewrite_lem handleRequestVoteReply_log_rewrite; eauto.
     - find_apply_hyp_hyp.
       match goal with
-        | _ : In ?p' (_ ++ _) |- _ => eapply in_aer with (p1 := p'); eauto
+        | _ : In ?p' (_ ++ _) |- _ => eapply @in_aer with (p := p'); eauto
       end.
     - repeat find_higher_order_rewrite.
       destruct_update; simpl in *; eauto.

--- a/raft-proofs/GhostLogLogMatchingProof.v
+++ b/raft-proofs/GhostLogLogMatchingProof.v
@@ -302,7 +302,7 @@ Section GhostLogLogMatching.
       + find_apply_hyp_hyp. intuition.
         * eauto.
         * packet_simpl.
-          erewrite handleAppendEntriesReply_log with (st'0 := d) by eauto.
+          erewrite @handleAppendEntriesReply_log with (st' := d) by eauto.
           eapply lifted_entries_match_invariant; eauto.
     - find_apply_hyp_hyp.
       find_apply_hyp_hyp.
@@ -337,7 +337,7 @@ Section GhostLogLogMatching.
       + find_apply_hyp_hyp. intuition.
         * eauto.
         * packet_simpl.
-          erewrite handleRequestVote_log with (st'0 := d) by eauto.
+          erewrite @handleRequestVote_log with (st' := d) by eauto.
           eapply lifted_entries_match_invariant; eauto.
     - find_apply_hyp_hyp.
       find_apply_hyp_hyp.
@@ -462,7 +462,7 @@ Section GhostLogLogMatching.
         * packet_simpl. eauto.
       + find_apply_hyp_hyp. intuition.
         packet_simpl.
-        erewrite doLeader_log with (st'0 := d') by eauto.
+        erewrite @doLeader_log with (st' := d') by eauto.
         eapply lifted_entries_match_invariant; eauto.
     - find_apply_hyp_hyp.
       find_apply_hyp_hyp.
@@ -495,7 +495,7 @@ Section GhostLogLogMatching.
         * packet_simpl. eauto.
       + find_apply_hyp_hyp. intuition.
         packet_simpl.
-        erewrite doGenericServer_log with (st'0 := d') by eauto.
+        erewrite @doGenericServer_log with (st' := d') by eauto.
         eapply lifted_entries_match_invariant; eauto.
     - find_apply_hyp_hyp.
       find_apply_hyp_hyp.

--- a/raft-proofs/LeaderLogsLogMatchingProof.v
+++ b/raft-proofs/LeaderLogsLogMatchingProof.v
@@ -292,7 +292,8 @@ Section LeaderLogsLogMatching.
     intros.
     find_apply_lem_hyp lifted_log_matching.
     unfold log_matching, log_matching_hosts in *.
-    intuition; repeat rewrite <- deghost_spec with (net0 := net).
+    rename net into net0.
+    intuition; repeat rewrite <- deghost_spec with (net := net0).
     - auto.
     - match goal with
         | [ H : _ |- _ ] => solve [apply H; rewrite deghost_spec; auto]
@@ -341,11 +342,12 @@ Section LeaderLogsLogMatching.
           conclude H ltac:(unfold deghost; simpl; eapply in_map_iff; eexists; eauto);
           conclude H ltac:(simpl; eauto)
     end.
+    rename net into net0.
     intuition.
-    - rewrite <- deghost_spec with (net0 := net).
+    - rewrite <- deghost_spec with (net := net0).
       eapply H3 with (e1:=e1)(e2:=e2); eauto.
       rewrite deghost_spec.  auto.
-    - rewrite <- deghost_spec with (net0 := net).
+    - rewrite <- deghost_spec with (net := net0).
       eapply H3 with (e1:=e1)(e2:=e2); eauto.
       rewrite deghost_spec.  auto.
   Qed.
@@ -383,7 +385,7 @@ Section LeaderLogsLogMatching.
         update_destruct_simplify; rewrite_update;
         try rewrite update_elections_data_appendEntries_leaderLogs in *; eauto.
         destruct (log d) using (handleAppendEntries_log_ind ltac:(eauto)); eauto.
-        + subst. eapply entries_match_scratch with (plt0 := plt).
+        + subst. eapply @entries_match_scratch with (plt := plt).
           * eauto using lifted_logs_sorted_nw.
           * apply sorted_uniqueIndices.
             eapply leaderLogs_sorted_invariant; eauto.
@@ -413,7 +415,7 @@ Section LeaderLogsLogMatching.
       find_erewrite_lem update_nop_ext'.
       find_apply_hyp_hyp. break_or_hyp.
       + intuition; match goal with
-            | [ H : _ |- _ ] => solve [eapply H with (p0 := p0); eauto with *]
+            | [ H : _ |- _ ] => solve [eapply (H _ _ _ p0); eauto with *]
           end.
       + simpl in *.
         find_copy_apply_lem_hyp handleAppendEntries_doesn't_send_AE.

--- a/raft-proofs/MatchIndexAllEntriesProof.v
+++ b/raft-proofs/MatchIndexAllEntriesProof.v
@@ -451,10 +451,10 @@ Section MatchIndexAllEntries.
     refined_raft_intermediate_reachable net ->
     terms_and_indices_from_one (log (snd (nwState net h))).
   Proof using taifoli rri. 
-    intros.
+    intros net0;intros.
     pose proof (lift_prop _ terms_and_indices_from_one_log_invariant).
     unfold terms_and_indices_from_one_log in *.
-    rewrite <- deghost_spec with (net0 := net). auto.
+    rewrite <- deghost_spec with (net := net0). auto.
   Qed.
 
   Lemma lifted_leader_sublog_nw :

--- a/raft-proofs/OneLeaderLogPerTermProof.v
+++ b/raft-proofs/OneLeaderLogPerTermProof.v
@@ -187,7 +187,7 @@ Section OneLeaderLogPerTerm.
     - split; [subst; auto|].
       find_copy_eapply_lem_hyp leaderLogs_update_elections_data_RVR; [|eauto].
       pose proof H.
-      eapply leaderLogs_update_elections_data_RVR with (ll0 := ll) in H; [|eauto].
+      eapply @leaderLogs_update_elections_data_RVR with (ll := ll) in H; [|eauto].
       intro_refined_invariant leaderLogs_currentTerm_sanity_candidate_invariant.
       intuition.
       + match goal with

--- a/raft-proofs/PrevLogLeaderSublogProof.v
+++ b/raft-proofs/PrevLogLeaderSublogProof.v
@@ -342,7 +342,7 @@ Section PrevLogLeaderSublogProof.
 
     match goal with
     | [ H : context [In _ _], H' : In _ _ |- _ ] =>
-      eapply H with (leader0 := leader) in H'; eauto
+      eapply (H leader) in H'; eauto
     end.
     - break_exists_exists. intuition.
       repeat find_higher_order_rewrite.

--- a/raft-proofs/StateMachineSafetyProof.v
+++ b/raft-proofs/StateMachineSafetyProof.v
@@ -149,8 +149,8 @@ Section StateMachineSafetyProof.
       msg_refined_raft_intermediate_reachable net ->
       sorted (log (snd (nwState net h))).
   Proof using rmri si rri. 
-    intros.
-    rewrite <- msg_deghost_spec with (net0 := net).
+    intros net0 ??.
+    rewrite <- msg_deghost_spec with (net := net0).
     eapply msg_lift_prop.
     - auto using lifted_sorted_host.
     - auto.
@@ -190,9 +190,9 @@ Section StateMachineSafetyProof.
     forall (net : ghost_log_network) h,
       snd (nwState net h) = nwState (deghost (mgv_deghost net)) h.
   Proof using rmri rri. 
-    intros.
+    intros net0 ?.
     rewrite deghost_spec.
-    rewrite msg_deghost_spec with (net0 := net).
+    rewrite msg_deghost_spec with (net := net0).
     auto.
   Qed.
 
@@ -320,7 +320,7 @@ Section StateMachineSafetyProof.
       sorted (log st').
   Proof using rmri si rri. 
     intros.
-    eapply handleAppendEntries_logs_sorted with (p0 := deghost_packet (mgv_deghost_packet p)).
+    eapply (handleAppendEntries_logs_sorted _ (deghost_packet (mgv_deghost_packet p))).
     - eauto using all_the_way_simulation_1.
     - apply lift_prop.
       + apply logs_sorted_invariant.
@@ -392,12 +392,12 @@ Section StateMachineSafetyProof.
        eIndex e > maxIndex entries \/
        In e entries).
   Proof using rmri rri. 
-    intros.
+    intros net0;intros.
     eapply lifted_sms_nw.
     - eauto.
     - eauto using in_mgv_ghost_packet.
     - rewrite pBody_mgv_deghost_packet. eauto.
-    - rewrite msg_deghost_spec with (net0 := net). eauto.
+    - rewrite msg_deghost_spec with (net := net0). eauto.
     - auto.
   Qed.
 
@@ -422,9 +422,9 @@ Section StateMachineSafetyProof.
       commit_recorded (deghost (mgv_deghost net)) h e.
   Proof using rmri rri. 
     unfold commit_recorded.
-    intros.
+    intros net0;intros.
     rewrite deghost_spec.
-    rewrite msg_deghost_spec with (net0 := net).
+    rewrite msg_deghost_spec with (net := net0).
     auto.
   Qed.
 
@@ -579,7 +579,7 @@ Section StateMachineSafetyProof.
         break_exists. intuition.
         match goal with
           | H : findAtIndex _ _ = None |- _ =>
-            eapply findAtIndex_None with (x1 := x) in H
+            eapply @findAtIndex_None with (x := x) in H
         end; eauto.
         * congruence.
         * apply msg_lifted_sorted_host. auto.
@@ -695,7 +695,7 @@ Section StateMachineSafetyProof.
         break_exists. intuition.
         match goal with
           | H : findAtIndex _ _ = None |- _ =>
-            eapply findAtIndex_None with (x1 := x) in H
+            eapply @findAtIndex_None with (x := x) in H
         end; eauto.
         * congruence.
         * apply msg_lifted_sorted_host; auto.
@@ -1580,12 +1580,12 @@ Section StateMachineSafetyProof.
       lifted_committed net e' t ->
       lifted_committed net e t.
   Proof using rmri tci. 
-    intros.
+    intros net0;intros.
     apply committed_lifted_committed.
     find_apply_lem_hyp lifted_committed_committed.
     repeat match goal with
              | H : _ |- _ =>
-               rewrite <- msg_deghost_spec with (net0 := net) in H
+               rewrite <- msg_deghost_spec with (net := net0) in H
            end.
     eapply transitive_commit_invariant; eauto.
     eapply msg_lift_prop; eauto.
@@ -2603,10 +2603,10 @@ Section StateMachineSafetyProof.
     refined_raft_intermediate_reachable net ->
     terms_and_indices_from_one (log (snd (nwState net h))).
   Proof using taifoli rri. 
-    intros.
+    intros net0;intros.
     pose proof (lift_prop _ terms_and_indices_from_one_log_invariant).
     unfold terms_and_indices_from_one_log in *.
-    rewrite <- deghost_spec with (net0 := net). auto.
+    rewrite <- deghost_spec with (net := net0). auto.
   Qed.
 
 

--- a/raft-proofs/TermsAndIndicesFromOneProof.v
+++ b/raft-proofs/TermsAndIndicesFromOneProof.v
@@ -23,14 +23,14 @@ Section TermsAndIndicesFromOne.
     simpl. contradiction.
   Qed.
 
-  Lemma lifted_terms_and_indices_from_one_log : forall net h,
-    refined_raft_intermediate_reachable net ->
-    terms_and_indices_from_one (log (snd (nwState net h))).
+  Lemma lifted_terms_and_indices_from_one_log : forall net0 h,
+    refined_raft_intermediate_reachable net0 ->
+    terms_and_indices_from_one (log (snd (nwState net0 h))).
   Proof using taifoli rri. 
     intros.
     pose proof (lift_prop _ terms_and_indices_from_one_log_invariant).
     unfold terms_and_indices_from_one_log in *.
-    rewrite <- deghost_spec with (net0 := net). auto.
+    rewrite <- deghost_spec with (net := net0). auto.
   Qed.
 
   Lemma terms_and_indices_from_one_vwl_client_request :


### PR DESCRIPTION
Should be backwards compatible.

(part2)

Note the strange `rewrite <- deghost_spec with (net0 := net).` to
`rename net into net0; rewrite <- deghost_spec with (net := net0).`
changes: here the usual `@` patch does not work because rewrite does
some black magic dependent on implicit arguments. When we drop backwards
compat we can just do the saner `rewrite <- deghost_spec with (net := net).`