### PR TITLE
Stop using ltac cast patterns

### DIFF
--- a/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
+++ b/raft-proofs/AppendEntriesRequestLeaderLogsProof.v
@@ -111,7 +111,7 @@ Section AppendEntriesRequestLeaderLogs.
   Ltac prove_in :=
     match goal with
       | [ _ : nwPackets ?net = _,
-              _ : In (?p : packet) _ |- _] =>
+              _ : In ?p _ |- _] =>
         assert (In p (nwPackets net)) by (repeat find_rewrite; do_in_app; intuition)
       | [ _ : nwPackets ?net = _,
               _ : pBody ?p = _ |- _] =>

--- a/raft-proofs/AppendEntriesRequestsCameFromLeadersProof.v
+++ b/raft-proofs/AppendEntriesRequestsCameFromLeadersProof.v
@@ -24,7 +24,7 @@ Section AppendEntriesRequestsCameFromLeaders.
   Ltac prove_in :=
     match goal with
       | [ _ : nwPackets ?net = _,
-              _ : In (?p : packet) _ |- _] =>
+              _ : In ?p _ |- _] =>
         assert (In p (nwPackets net)) by (repeat find_rewrite; do_in_app; intuition)
       | [ _ : nwPackets ?net = _,
               _ : pBody ?p = _ |- _] =>

--- a/raft-proofs/CandidateEntriesProof.v
+++ b/raft-proofs/CandidateEntriesProof.v
@@ -370,7 +370,7 @@ Section CandidateEntriesProof.
   Ltac prove_in :=
     match goal with
       | [ _ : nwPackets ?net = _,
-              _ : In (?p : packet) _ |- _] =>
+              _ : In ?p _ |- _] =>
         assert (In p (nwPackets net)) by (repeat find_rewrite; do_in_app; intuition)
       | [ _ : nwPackets ?net = _,
               _ : pBody ?p = _ |- _] =>

--- a/raft-proofs/LeaderSublogProof.v
+++ b/raft-proofs/LeaderSublogProof.v
@@ -32,7 +32,7 @@ Section LeaderSublogProof.
   Ltac prove_in :=
     match goal with
       | [ _ : nwPackets ?net = _,
-              _ : In (?p : packet) _ |- _] =>
+              _ : In ?p _ |- _] =>
         assert (In p (nwPackets net)) by (repeat find_rewrite; do_in_app; intuition)
       | [ _ : nwPackets ?net = _,
               _ : pBody ?p = _ |- _] =>

--- a/raft-proofs/LogMatchingProof.v
+++ b/raft-proofs/LogMatchingProof.v
@@ -233,7 +233,7 @@ Section LogMatchingProof.
         break_if;
         match goal with
           | [ _ : eIndex ?e = eIndex ?e',
-              H : forall _ _ _, In _ _ -> _ |- context [(?h : name) ] ] =>
+              H : forall _ _ _, In _ _ -> _ |- context [?h] ] =>
               specialize (H h e e')
         end; repeat concludes; intuition.
       + simpl in *.
@@ -410,7 +410,7 @@ Section LogMatchingProof.
           end. intuition.
           forwards;
             [match goal with
-               | H : forall _, In _ _ -> _ < _ |- context [ (?e : entry) ] =>
+               | H : forall _, In _ _ -> _ < _ |- context [ ?e ] =>
                  specialize (H e)
              end; concludes; lia|].
           concludes.

--- a/raft-proofs/LogsLeaderLogsProof.v
+++ b/raft-proofs/LogsLeaderLogsProof.v
@@ -182,7 +182,7 @@ Section LogsLeaderLogs.
   Ltac prove_in :=
     match goal with
       | [ _ : nwPackets ?net = _,
-              _ : In (?p : packet) _ |- _] =>
+              _ : In ?p _ |- _] =>
         assert (In p (nwPackets net)) by (repeat find_rewrite; do_in_app; intuition)
       | [ _ : nwPackets ?net = _,
               _ : pBody ?p = _ |- _] =>


### PR DESCRIPTION
`x : y` as a ltac pattern was equivalent to `x` and will be removed in https://github.com/coq/coq/pull/16798