### PR TITLE
Adapt to Coq PR #17084: maximal implicit arguments now added by default to references in defined Ltac code.

### DIFF
--- a/raft-proofs/LeaderLogsTermSanityProof.v
+++ b/raft-proofs/LeaderLogsTermSanityProof.v
@@ -49,7 +49,7 @@ Section LeaderLogsTermSanity.
       pose lem; eauto.
 
   Tactic Notation "term_sanity_unchanged" constr(lem) := term_sanity_unchanged' lem.
-  Tactic Notation "term_sanity_unchanged" := term_sanity_unchanged' eq_refl (* bogus *).
+  Tactic Notation "term_sanity_unchanged" := term_sanity_unchanged' (@eq_refl) (* bogus *).
 
   Lemma leaderLogs_term_sanity_request_vote_reply :
     refined_raft_net_invariant_request_vote_reply leaderLogs_term_sanity.


### PR DESCRIPTION
Hi, coq/coq#17084 intends to make uniform the interpretation of references depending on whether the reference is interpreted at toplevel or within an Ltac definitions or tactic notations. In particular, it now always insert maximal implicit arguments, like already the case at toplevel, even when in Ltac definition or tactic notation.

As a consequence, in `LeaderLogsTermSanityProof.v`, an `eq_refl` must be changed to `@eq_refl` to preserve the original behavior, in anticipation of coq/coq#17084.

This is backwards compatible and can be merged as soon as now.